### PR TITLE
docs: elaborate Milestone 1 epics into implementation-ready specs

### DIFF
--- a/docs/epics/01-core-infrastructure.md
+++ b/docs/epics/01-core-infrastructure.md
@@ -36,7 +36,7 @@ Establishes the foundational persistence and event layer that every other epic b
 - [x] WAL mode: yes, enabled by default with `synchronous=FULL` for crash safety (D2, D3)
 - [x] Event bus implementation: SQLite WAL-mode queue with poll + mark-complete consumer — no in-process EventEmitter (D3)
 - [x] Task schema minimum fields: `task_id`, `state`, `channel`, `created_at`, `updated_at`, `correlation_id` (Epic 0, Section 6)
-- [ ] Migration tool: raw SQL files, a migration library, or hand-rolled?
+- [x] Migration tool: Raw SQL files + hand-rolled runner. Numbered `.sql` files in `migrations/` (e.g., `001_initial_schema.sql`), `schema_version` table tracks applied migrations, runner reads in order, skips applied, wraps each in a transaction (~50 lines TS). Rationale: Node.js >=22 has built-in `node:sqlite`, schema is small (5-7 tables), avoids external deps, satisfies idempotency success metric.
 
 ## Success Metrics
 
@@ -65,17 +65,176 @@ Establishes the foundational persistence and event layer that every other epic b
 
 ## Stories
 
-> Placeholder — to become GitHub issues.
+### S1.1: Define task schema
 
-- [ ] Define task schema (including `correlation_id` for OTLP trace linkage)
-- [ ] Implement SQLite setup and migration runner
-- [ ] Implement task state machine
-- [ ] Implement event queue (SQLite WAL poll + mark-complete consumer, D3)
-- [ ] Define `triage_log` table schema (decision, confidence, latency, channel, mode — D13)
-- [ ] Define `event_queue` + `amara_dlq` tables (at-least-once delivery, poison message handling — D3)
-- [ ] Implement poison message detection and DLQ routing
-- [ ] Write crash-recovery test
-- [ ] Export and document task CRUD API
+**Description:** Define the SQLite task table schema based on Epic 0 §6. Includes all minimum fields plus any additional columns identified during architecture review. Output is a numbered migration SQL file.
+
+**Acceptance Criteria:**
+- [ ] Migration file `001_initial_schema.sql` exists with `CREATE TABLE tasks`
+- [ ] Columns include: `task_id`, `state`, `channel`, `created_at`, `updated_at`, `correlation_id`
+- [ ] `task_id` is a TEXT primary key (ULID or UUID)
+- [ ] `state` column has a CHECK constraint for valid states
+- [ ] Schema documented in a comment block at top of migration file
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** S1.3, S1.9, S2.5, S3.3, S3.4
+
+---
+
+### S1.2: Implement SQLite setup and migration runner
+
+**Description:** Create the hand-rolled migration runner that manages `~/.amara/tasks.db`. Uses Node.js built-in `node:sqlite`. Reads numbered `.sql` files from `migrations/`, tracks applied migrations in a `schema_version` table, skips already-applied migrations, and wraps each in a transaction.
+
+**Acceptance Criteria:**
+- [ ] `schema_version` table created automatically on first run
+- [ ] Runner reads `migrations/*.sql` files in numeric order
+- [ ] Already-applied migrations are skipped (idempotent)
+- [ ] Each migration runs inside a transaction (rollback on failure)
+- [ ] WAL mode enabled with `synchronous=FULL`
+- [ ] Runner is ~50 lines, no external dependencies
+
+**Size:** M
+**Dependencies:** None
+**Blocks:** S1.3, S1.4, S1.5, S1.6, S2.5, S2.6
+
+---
+
+### S1.3: Implement task state machine
+
+**Description:** Implement the state machine that enforces valid task transitions: `pending → in_progress → blocked → complete | failed`. Invalid transitions throw a typed error with the current state, attempted state, and task ID.
+
+**Acceptance Criteria:**
+- [ ] Valid transitions: `pending→in_progress`, `in_progress→blocked`, `in_progress→complete`, `in_progress→failed`, `blocked→in_progress`, `blocked→failed`
+- [ ] Invalid transitions throw `InvalidStateTransitionError` with context
+- [ ] State changes update `updated_at` timestamp
+- [ ] Unit tests cover all valid transitions and at least 3 invalid transitions
+
+**Size:** M
+**Dependencies:** S1.1, S1.2
+**Blocks:** S1.8, S1.9
+
+---
+
+### S1.4: Implement event queue
+
+**Description:** Implement the SQLite WAL-mode event queue with poll + mark-complete consumer pattern (D3). Events are written to the `event_queue` table by producers and consumed by polling consumers that mark events as complete after processing.
+
+**Acceptance Criteria:**
+- [ ] Events enqueued with `event_id`, `event_type`, `payload`, `created_at`, `status`
+- [ ] Consumer polls for `pending` events in FIFO order
+- [ ] Consumer marks events `complete` after successful processing
+- [ ] At-least-once delivery: unacknowledged events re-delivered after timeout
+- [ ] Unit test: enqueue → consume → mark-complete cycle works
+
+**Size:** M
+**Dependencies:** S1.2, S1.6
+**Blocks:** S1.7, S1.8, S2.6
+
+---
+
+### S1.5: Define triage_log table schema
+
+**Description:** Define the `triage_log` table for recording triage decisions (D13, Section 7). This table feeds the dashboard triage activity feed (Epic 10) and triage decision metrics (Epic 3).
+
+**Acceptance Criteria:**
+- [ ] Migration file creates `triage_log` table
+- [ ] Columns include: `log_id`, `task_id`, `decision`, `confidence`, `latency_ms`, `channel`, `mode`, `created_at`
+- [ ] `decision` column documents expected values (e.g., archive, label, escalate, draft_reply)
+- [ ] Subject to 30-day PII retention policy (documented in schema comment)
+
+**Size:** S
+**Dependencies:** S1.2
+**Blocks:** S2.5, S3.8, S10.5
+
+---
+
+### S1.6: Define event_queue + amara_dlq tables
+
+**Description:** Define the `event_queue` and `amara_dlq` (dead-letter queue) table schemas for at-least-once delivery and poison message storage (D3, Section 3 P0).
+
+**Acceptance Criteria:**
+- [ ] Migration file creates `event_queue` table with: `event_id`, `event_type`, `payload`, `status`, `retry_count`, `created_at`, `updated_at`
+- [ ] Migration file creates `amara_dlq` table with: `dlq_id`, `original_event_id`, `event_type`, `payload`, `failure_reason`, `moved_at`
+- [ ] `status` CHECK constraint: `pending`, `processing`, `complete`, `failed`
+- [ ] Schema comments document the at-least-once delivery contract
+
+**Size:** S
+**Dependencies:** S1.2
+**Blocks:** S1.4, S1.7, S2.5
+
+---
+
+### S1.7: Implement poison message detection and DLQ routing
+
+**Description:** Implement logic that detects poison messages (events that fail processing repeatedly) and routes them to the dead-letter queue. After 3 consecutive failures, the event is moved from `event_queue` to `amara_dlq` and an OTLP alert is emitted.
+
+**Acceptance Criteria:**
+- [ ] Events with `retry_count >= 3` are moved to `amara_dlq`
+- [ ] Original event marked as `failed` in `event_queue`
+- [ ] DLQ record includes `failure_reason` from last attempt
+- [ ] OTLP span/event emitted when a message is DLQ'd
+- [ ] Unit test: simulate 3 failures → verify DLQ routing
+
+**Size:** M
+**Dependencies:** S1.4, S1.6
+**Blocks:** None
+
+---
+
+### S1.8: Write crash-recovery test
+
+**Description:** Integration test that verifies task and event persistence across a simulated crash. Kills the process mid-operation and restarts, then verifies that committed data survived and uncommitted data did not corrupt the database.
+
+**Acceptance Criteria:**
+- [ ] Test creates tasks and enqueues events
+- [ ] Process is killed (SIGKILL or equivalent)
+- [ ] After restart, committed tasks are present with correct state
+- [ ] After restart, committed events are present and consumable
+- [ ] SQLite integrity check passes after recovery
+- [ ] Test runs in CI without flakiness
+
+**Size:** M
+**Dependencies:** S1.3, S1.4
+**Blocks:** None
+
+---
+
+### S1.9: Export and document task CRUD API
+
+**Description:** Define and export the public TypeScript API surface for task create/read/update/delete operations. This is the interface consumed by the orchestrator (Epic 5), agents (Epic 9), and dashboard (Epic 10).
+
+**Acceptance Criteria:**
+- [ ] Exported functions: `createTask`, `getTask`, `listTasks`, `updateTask`, `deleteTask`
+- [ ] Each function has TypeScript types for params and return values
+- [ ] JSDoc comments on each exported function
+- [ ] Functions enforce state machine rules (delegates to S1.3)
+- [ ] Integration test: full CRUD cycle
+
+**Size:** S
+**Dependencies:** S1.3
+**Blocks:** S3.4, S10.2
+
+## Story Sequencing
+
+```
+Phase 1 (parallel start):
+  S1.1: Define task schema ─────────────┐
+  S1.2: SQLite setup + migration runner ─┤
+                                         │
+Phase 2 (unblocked by Phase 1):         │
+  S1.3: Task state machine ◄────────────┤ (needs S1.1, S1.2)
+  S1.5: triage_log schema ◄─────────────┤ (needs S1.2)
+  S1.6: event_queue + DLQ schemas ◄─────┘ (needs S1.2)
+                                         │
+Phase 3 (unblocked by Phase 2):         │
+  S1.4: Event queue impl ◄──────────────┤ (needs S1.2, S1.6)
+  S1.9: Task CRUD API ◄─────────────────┤ (needs S1.3)
+                                         │
+Phase 4 (unblocked by Phase 3):         │
+  S1.7: Poison message + DLQ ◄──────────┤ (needs S1.4, S1.6)
+  S1.8: Crash-recovery test ◄───────────┘ (needs S1.3, S1.4)
+```
 
 ## Dependencies
 
@@ -86,3 +245,4 @@ Establishes the foundational persistence and event layer that every other epic b
 - ~~What fields does a Task record need at minimum?~~ **Resolved:** `task_id`, `state`, `channel`, `created_at`, `updated_at`, `correlation_id` (Epic 0, Section 6)
 - ~~Should the event bus be synchronous or async?~~ **Resolved:** Async — SQLite WAL queue with poll consumer (D3)
 - ~~Do we need soft-delete on tasks, or just a `failed`/`cancelled` state?~~ **Resolved:** No soft-delete; use `failed` state for terminal failures (Epic 0, Section 7)
+- ~~Migration tool: raw SQL files, a migration library, or hand-rolled?~~ **Resolved:** Raw SQL files + hand-rolled runner. Numbered `.sql` files in `migrations/`, `schema_version` table tracks applied migrations, ~50 lines TS. Node.js >=22 built-in `node:sqlite` eliminates external deps.

--- a/docs/epics/02-security-and-privacy.md
+++ b/docs/epics/02-security-and-privacy.md
@@ -68,16 +68,163 @@ Establishes the security and privacy contracts for Amara before channels or depl
 
 ## Stories
 
-> Placeholder — to become GitHub issues.
+### S2.1: Define OAuth scopes per channel
 
-- [ ] Define OAuth scopes per channel (scopes listed in Epic 0, Section 9)
-- [ ] Implement secret storage (delegates to OpenClaw auth-profiles — D9)
-- [ ] Write log-sanitization test (secrets must not appear in output)
-- [ ] Define PII inventory and retention policy (90-day tasks, 30-day triage_log — Section 9)
-- [ ] Implement delete-my-data 7-step process (Epic 0, Section 9)
-- [ ] Define and wire security audit log
-- [ ] Implement D14 write permission audit logging (all outbound sends on monitored channels)
-- [ ] Document input validation contracts
+**Description:** Document the minimum OAuth scopes required for each channel (WhatsApp, Gmail, Calendar) with explicit justification for each scope. Output is a reference table in this epic and inline in channel adapter docs.
+
+**Acceptance Criteria:**
+- [ ] Scopes listed for Gmail (read, send, labels, drafts)
+- [ ] Scopes listed for Calendar (read, write events)
+- [ ] Scopes listed for WhatsApp (read, send messages)
+- [ ] Each scope has a one-line justification
+- [ ] "Why not broader?" rationale documented for any scope that could be narrower
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** None
+
+---
+
+### S2.2: Implement secret storage
+
+**Description:** Verify and document the OpenClaw auth-profiles integration (D9) for storing OAuth tokens and other secrets. Confirm the file-based storage at `~/.openclaw/agents/{agentId}/agent/auth-profiles.json` works for Amara's needs.
+
+**Acceptance Criteria:**
+- [ ] Auth-profiles path confirmed and documented
+- [ ] Token read/write/refresh cycle verified against OpenClaw API
+- [ ] Refresh failure detection and human-alert path documented
+- [ ] No secrets stored outside of auth-profiles (no `.env`, no in-memory caching beyond request scope)
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** None
+
+---
+
+### S2.3: Write log-sanitization test
+
+**Description:** Automated test that verifies OAuth tokens, API keys, and other secrets never appear in structured log output at any log level. Depends on the structured logging standard from Epic 3 (S3.1).
+
+**Acceptance Criteria:**
+- [ ] Test injects known secret values into a request context
+- [ ] Test captures all log output from a simulated request lifecycle
+- [ ] Test asserts none of the injected secrets appear in captured output
+- [ ] Covers all log levels: debug, info, warn, error
+- [ ] Test fails if a new log statement leaks a secret (regression guard)
+
+**Size:** M
+**Dependencies:** S3.1 (structured logging standard)
+**Blocks:** None
+
+---
+
+### S2.4: Define PII inventory and retention policy
+
+**Description:** Document all user data Amara stores, why it's stored, and how long it's retained. This is a policy document that gates data deletion implementation.
+
+**Acceptance Criteria:**
+- [ ] Inventory table: data field, storage location, purpose, retention period
+- [ ] Task data: 90-day retention from creation
+- [ ] Triage log: 30-day retention from creation
+- [ ] OAuth tokens: exempt from auto-purge (managed by OpenClaw)
+- [ ] Audit logs: retention period documented (recommended: 1 year)
+- [ ] Purge mechanism described (scheduled job or on-access check)
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** None
+
+---
+
+### S2.5: Implement delete-my-data 7-step process
+
+**Description:** Implement the complete data deletion process from Epic 0, Section 9. Must cover all tables across all stores. This is the largest story in Epic 2 because it touches every table defined in Epic 1.
+
+**Acceptance Criteria:**
+- [ ] Step 1: Delete all tasks owned by the user
+- [ ] Step 2: Delete all triage_log entries
+- [ ] Step 3: Delete all event_queue entries (pending and complete)
+- [ ] Step 4: Delete all amara_dlq entries
+- [ ] Step 5: Delete audit log entries
+- [ ] Step 6: Clear cached credentials and agent session data
+- [ ] Step 7: Reset config to defaults (preserve install, remove user data)
+- [ ] Each step is idempotent (safe to re-run)
+- [ ] Integration test: populate all tables → delete → verify empty
+- [ ] Returns a receipt listing what was deleted (counts per table)
+
+**Size:** L
+**Dependencies:** S1.1, S1.2, S1.5, S1.6
+**Blocks:** None
+
+---
+
+### S2.6: Define and wire security audit log
+
+**Description:** Create a dedicated security audit log table in SQLite for security-sensitive events. Wire it to the event bus so security events are automatically captured.
+
+**Acceptance Criteria:**
+- [ ] `security_audit_log` table created with: `log_id`, `event_type`, `actor`, `target`, `details`, `created_at`
+- [ ] Event types include: `oauth_exchange`, `token_rotation`, `token_revocation`, `write_permission_grant`, `data_deletion`
+- [ ] Events published to event bus are captured by audit log listener
+- [ ] Query API: filter by event type, date range
+- [ ] Unit test: emit security event → verify audit log entry
+
+**Size:** M
+**Dependencies:** S1.2, S1.4
+**Blocks:** S2.7, S10.3
+
+---
+
+### S2.7: Implement D14 write permission audit logging
+
+**Description:** Ensure all outbound sends on monitored channels (Gmail send, Calendar event create, WhatsApp message) are logged in the security audit log with the grant type that authorized the action.
+
+**Acceptance Criteria:**
+- [ ] Every outbound write action logged with: channel, action type, grant type, timestamp
+- [ ] Grant types documented: `user_explicit`, `standing_rule`, `auto_approved`
+- [ ] Log entry includes enough context to reconstruct what was sent (but NOT the full message body — PII)
+- [ ] Unit test: simulate outbound send → verify audit log entry with grant type
+
+**Size:** M
+**Dependencies:** S2.6
+**Blocks:** None
+
+---
+
+### S2.8: Document input validation contracts
+
+**Description:** Document the validation rules and sanitization applied to all external inputs entering Amara (channel messages, API requests, config values). This is a reference document for implementers of channel adapters and API endpoints.
+
+**Acceptance Criteria:**
+- [ ] Validation rules documented for: message text, email addresses, calendar dates, task IDs
+- [ ] Sanitization rules documented: HTML stripping, URL validation, size limits
+- [ ] Maximum input sizes documented per field
+- [ ] Error response format documented for validation failures
+- [ ] Document is referenced from channel adapter epic (Epic 8) scope
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** None
+
+## Story Sequencing
+
+```
+Phase 1 (parallel start — documentation stories):
+  S2.1: OAuth scopes ──────────────────┐
+  S2.2: Secret storage verification ───┤
+  S2.4: PII inventory + retention ─────┤
+  S2.8: Input validation contracts ────┘
+
+Phase 2 (blocked on cross-epic deps):
+  S2.3: Log-sanitization test ◄──────── (needs S3.1 from Epic 3)
+  S2.6: Security audit log ◄────────── (needs S1.2, S1.4 from Epic 1)
+
+Phase 3 (blocked on Phase 2):
+  S2.7: Write permission audit ◄─────── (needs S2.6)
+
+Phase 4 (blocked on Epic 1 tables):
+  S2.5: Delete-my-data ◄────────────── (needs S1.1, S1.2, S1.5, S1.6)
+```
 
 ## Dependencies
 

--- a/docs/epics/03-observability-and-quality.md
+++ b/docs/epics/03-observability-and-quality.md
@@ -33,8 +33,10 @@ Wires in tracing, structured logging, agent outcome scoring, failure taxonomy, a
 
 - [x] Log format and trace context: OTLP/OpenTelemetry — native to OpenClaw, not overkill (D0, Section 2 capabilities matrix)
 - [x] Where are agent outcome scores stored? Amara Task DB (`~/.amara/tasks.db`) alongside task records (D2)
-- [ ] Eval harness: what's the interface? (CLI? test runner? notebook?)
-- [ ] Failure taxonomy: who owns it and how is it extended?
+- [x] Eval harness: Separate `*.eval.ts` files + `npm run eval`. Same runner (`node --test`), separate file convention: unit tests = `*.test.ts`, evals = `*.eval.ts`. Add `"eval": "node --test **/*.eval.ts"` to package.json. Evals replay task histories, compare outcomes — slow by nature, should not block fast unit tests.
+- [x] Failure taxonomy: Epic 3 defines the base taxonomy as a TypeScript string union in `src/types/failures.ts`. Base categories: `api_failure`, `agent_failure`, `task_failure`, `triage_error`, `poison_message`, `auth_failure`, `validation_failure`. Epics 5 and 9 extend the union with domain-specific categories. Epic 3 owns the base + extension documentation.
+- [x] Evals in `node --test` or separate? Same runner, separate command. `npm test` runs `*.test.ts`, `npm run eval` runs `*.eval.ts`.
+- [x] Outcome score thresholds: Config-driven with documented defaults. >0.95 confidence for destructive triage actions, >0.7 for escalation. Runtime configuration via `~/.amara/config.yaml`. Enforced by orchestrator (Epic 5) and triage layer. Users can tune thresholds without code changes.
 
 ## Success Metrics
 
@@ -64,16 +66,154 @@ Wires in tracing, structured logging, agent outcome scoring, failure taxonomy, a
 
 ## Stories
 
-> Placeholder — to become GitHub issues.
+### S3.1: Define structured logging standard
 
-- [ ] Define structured logging standard
-- [ ] Implement OTLP/OpenTelemetry integration (native to OpenClaw — D0)
-- [ ] Implement correlation ID propagation (correlation_id on tasks links to OTLP traces)
-- [ ] Define and implement agent outcome scoring
-- [ ] Document failure taxonomy
-- [ ] Build eval harness
-- [ ] Define metrics and their collection points
-- [ ] Implement triage decision metrics (latency, confidence, escalation rate — D13, Section 8)
+**Description:** Document the structured logging convention (field names, levels, required fields) and add a lint rule or test that enforces it. This standard is consumed by every epic and specifically unblocks S2.3 (log-sanitization test).
+
+**Acceptance Criteria:**
+- [ ] Logging standard document: required fields (`timestamp`, `level`, `correlation_id`, `component`), optional fields, format (JSON)
+- [ ] Log levels defined: `debug`, `info`, `warn`, `error`
+- [ ] No-PII-in-logs rule documented with examples of what's allowed vs. forbidden
+- [ ] Lint rule or test that catches unstructured `console.log` in `src/`
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** S2.3, S3.3
+
+---
+
+### S3.2: Implement OTLP/OpenTelemetry integration
+
+**Description:** Wire up OpenTelemetry tracing using OpenClaw's native OTLP support (D0). Configure the trace exporter, set up the global tracer provider, and verify spans are emitted for a basic request lifecycle.
+
+**Acceptance Criteria:**
+- [ ] OpenTelemetry SDK initialized at process startup
+- [ ] OTLP exporter configured (endpoint configurable via env var)
+- [ ] Basic span created for a sample operation (e.g., task state transition)
+- [ ] Span attributes include `correlation_id`, `component`, `operation`
+- [ ] Integration test: verify span is exported (use in-memory exporter for test)
+
+**Size:** M
+**Dependencies:** None
+**Blocks:** S3.3, S3.7, S3.8
+
+---
+
+### S3.3: Implement correlation ID propagation
+
+**Description:** Ensure the `correlation_id` field from the tasks table is propagated through all OTLP spans and structured log entries for a request lifecycle. Any log or span produced while processing a task must include that task's correlation ID.
+
+**Acceptance Criteria:**
+- [ ] `correlation_id` from task record injected into OTLP trace context
+- [ ] All structured log entries within a task's processing include `correlation_id`
+- [ ] Propagation works across event bus boundaries (producer → consumer)
+- [ ] Integration test: create task → process event → verify correlation_id in all spans/logs
+
+**Size:** M
+**Dependencies:** S1.1, S3.2
+**Blocks:** None
+
+---
+
+### S3.4: Define and implement agent outcome scoring
+
+**Description:** Define the outcome scoring schema (success / partial / failed / escalated) and implement storage in the Task DB. Scores are written when an agent completes work on a task.
+
+**Acceptance Criteria:**
+- [ ] Outcome enum: `success`, `partial`, `failed`, `escalated`
+- [ ] `outcome` and `outcome_score` columns added to tasks table (via migration)
+- [ ] `outcome_score` is a float 0.0–1.0 representing confidence
+- [ ] Scoring function exported for agents to call
+- [ ] Unit test: score a task → read back → verify outcome and score
+
+**Size:** M
+**Dependencies:** S1.1, S1.9
+**Blocks:** S3.6
+
+---
+
+### S3.5: Document failure taxonomy
+
+**Description:** Define the base failure taxonomy as a TypeScript string union type. Document each category with examples, expected frequency, and how it should be handled (retry, alert, escalate, DLQ).
+
+**Acceptance Criteria:**
+- [ ] `src/types/failures.ts` exports base union type with categories: `api_failure`, `agent_failure`, `task_failure`, `triage_error`, `poison_message`, `auth_failure`, `validation_failure`
+- [ ] Each category has a JSDoc comment with: definition, example, handling strategy
+- [ ] Extension rules documented: how Epics 5 and 9 add domain-specific categories
+- [ ] Mapping table: failure category → recommended action (retry/alert/escalate/DLQ)
+
+**Size:** S
+**Dependencies:** None
+**Blocks:** S3.6
+
+---
+
+### S3.6: Build eval harness
+
+**Description:** Implement the evaluation harness that replays task histories and compares outcomes. Uses `*.eval.ts` file convention and runs via `npm run eval`. Evals are separate from unit tests to avoid slowing down the fast test suite.
+
+**Acceptance Criteria:**
+- [ ] `"eval": "node --test **/*.eval.ts"` added to package.json scripts
+- [ ] At least one sample eval file exists demonstrating the pattern
+- [ ] Eval replays a recorded task history (fixture file)
+- [ ] Eval compares actual vs. expected outcome using scoring from S3.4
+- [ ] Eval uses failure taxonomy from S3.5 for classification
+- [ ] `npm run eval` exits 0 on pass, non-zero on failure
+
+**Size:** L
+**Dependencies:** S3.4, S3.5
+**Blocks:** None
+
+---
+
+### S3.7: Define metrics and their collection points
+
+**Description:** Document all OTLP metrics Amara will emit, where they are emitted from (collection points), and who consumes them. This is a reference document that guides instrumentation across all epics.
+
+**Acceptance Criteria:**
+- [ ] Metrics inventory table: metric name, type (counter/histogram/gauge), unit, collection point, consumer
+- [ ] Core metrics defined: `task_latency`, `task_success_rate`, `escalation_rate`, `stall_rate`, `event_queue_depth`
+- [ ] Collection points identified for each metric (which module/function emits it)
+- [ ] OTLP metric emission verified for at least one metric (integration test)
+
+**Size:** S
+**Dependencies:** S3.2
+**Blocks:** S3.8
+
+---
+
+### S3.8: Implement triage decision metrics
+
+**Description:** Implement metrics collection for triage decisions: latency (P95 <200ms target), confidence scores, and escalation rate. Reads from the `triage_log` table and emits OTLP metrics.
+
+**Acceptance Criteria:**
+- [ ] Triage latency histogram emitted per decision (from `triage_log.latency_ms`)
+- [ ] Confidence score histogram emitted per decision
+- [ ] Escalation rate counter: total decisions vs. escalated decisions
+- [ ] Metrics tagged with `channel` and `mode` dimensions
+- [ ] Unit test: insert triage_log entries → verify metrics emitted with correct values
+
+**Size:** M
+**Dependencies:** S1.5, S3.2, S3.7
+**Blocks:** None
+
+## Story Sequencing
+
+```
+Phase 1 (parallel start):
+  S3.1: Structured logging standard ───┐
+  S3.2: OTLP/OpenTelemetry integration ┤
+  S3.5: Failure taxonomy ──────────────┘
+
+Phase 2 (unblocked by Phase 1):
+  S3.3: Correlation ID propagation ◄──── (needs S1.1, S3.2)
+  S3.4: Agent outcome scoring ◄───────── (needs S1.1, S1.9)
+  S3.7: Metrics + collection points ◄─── (needs S3.2)
+
+Phase 3 (unblocked by Phase 2):
+  S3.6: Eval harness ◄──────────────────  (needs S3.4, S3.5)
+  S3.8: Triage decision metrics ◄──────── (needs S1.5, S3.2, S3.7)
+```
 
 ## Dependencies
 
@@ -83,5 +223,5 @@ Wires in tracing, structured logging, agent outcome scoring, failure taxonomy, a
 ## Open Questions
 
 - ~~Is OpenTelemetry the right choice for a single-user personal assistant, or is it overkill?~~ **Resolved:** Not overkill — OTLP is native to OpenClaw; we get it for free (D0, Section 2)
-- Should evals be part of `node --test` or a separate command?
-- Who defines acceptable outcome score thresholds?
+- ~~Should evals be part of `node --test` or a separate command?~~ **Resolved:** Same runner (`node --test`), separate command. `npm test` runs `*.test.ts`, `npm run eval` runs `*.eval.ts`. Evals are slow by nature and should not block fast unit tests.
+- ~~Who defines acceptable outcome score thresholds?~~ **Resolved:** Config-driven with documented defaults. >0.95 for destructive triage actions, >0.7 for escalation. Runtime config via `~/.amara/config.yaml`; enforced by orchestrator (Epic 5).

--- a/docs/epics/10-dashboard.md
+++ b/docs/epics/10-dashboard.md
@@ -35,7 +35,7 @@ A minimal web UI for task visibility: active tasks, pending tasks, history, and 
 - [x] Refresh model: OpenClaw WebSocket push — not polling (Epic 0, Section 6)
 - [x] Auth: localhost-only, no auth for v1 (single-user personal assistant)
 - [x] Where does the dashboard server run? Same process — Gateway HTTP endpoint (D8)
-- [ ] Mobile breakpoint strategy (deferred to Milestone 6)
+- [x] Mobile breakpoint strategy: Milestone 1 delivers basic responsive CSS for 390px viewport (iPhone 14 baseline). Full mobile polish (PWA, native-like interactions, gesture support) deferred to Milestone 6.
 
 ## Success Metrics
 
@@ -64,16 +64,165 @@ A minimal web UI for task visibility: active tasks, pending tasks, history, and 
 
 ## Stories
 
-> Placeholder — to become GitHub issues.
+### S10.1: Set up Canvas/A2UI project
 
-- [ ] Set up Canvas/A2UI project (D8)
-- [ ] Implement active/pending/history views
-- [ ] Implement audit log view
-- [ ] Implement task detail view (including triage sub-task detail for visibility)
-- [ ] Implement triage activity feed (recent decisions from triage_log — D13)
-- [ ] Implement undo controls for reversible triage actions (D14)
-- [ ] Mobile layout pass
-- [ ] Dashboard server integration (same-process Gateway endpoint — D8)
+**Description:** Scaffold the dashboard project using OpenClaw Canvas/A2UI (D8). Set up the build pipeline, dev server, and basic shell layout (header, navigation, content area).
+
+**Acceptance Criteria:**
+- [ ] Canvas/A2UI project initialized with build configuration
+- [ ] Dev server starts and serves an empty shell page
+- [ ] Basic layout shell: header with "Amara" title, sidebar/tab navigation, main content area
+- [ ] Build produces static assets suitable for embedding in Gateway
+- [ ] `npm run dev` starts hot-reloading dev server
+
+**Size:** M
+**Dependencies:** None
+**Blocks:** S10.2, S10.3, S10.5, S10.8
+
+---
+
+### S10.2: Implement active/pending/history views
+
+**Description:** Three list views showing tasks from the Task DB via the CRUD API (S1.9): active (in_progress, blocked), pending, and history (complete, failed). Each view shows task summary with state badge, channel, and timestamps.
+
+**Acceptance Criteria:**
+- [ ] Active view: lists tasks with state `in_progress` or `blocked`
+- [ ] Pending view: lists tasks with state `pending`
+- [ ] History view: lists tasks with state `complete` or `failed`
+- [ ] Each task row shows: task_id (truncated), state badge, channel, created_at, updated_at
+- [ ] Views update via WebSocket push (no manual refresh needed)
+- [ ] Empty state message when no tasks match the view
+
+**Size:** L
+**Dependencies:** S1.9, S10.1, S10.8
+**Blocks:** S10.4, S10.7
+
+---
+
+### S10.3: Implement audit log view
+
+**Description:** Filterable view of the security audit log (S2.6). Users can filter by event type and date range. Shows recent audit entries in reverse chronological order.
+
+**Acceptance Criteria:**
+- [ ] Displays audit log entries in reverse chronological order
+- [ ] Filter by event type (dropdown: oauth_exchange, token_rotation, etc.)
+- [ ] Filter by date range (start date, end date)
+- [ ] Each entry shows: timestamp, event_type, actor, target, details summary
+- [ ] Pagination or infinite scroll for large result sets
+
+**Size:** M
+**Dependencies:** S2.6, S10.1, S10.8
+**Blocks:** S10.7
+
+---
+
+### S10.4: Implement task detail view
+
+**Description:** Full detail view for a single task showing its complete lifecycle: state transitions, triage sub-tasks, outcome score, correlation ID, and associated events.
+
+**Acceptance Criteria:**
+- [ ] Navigable from any task list view (click task → detail)
+- [ ] Shows all task fields: task_id, state, channel, correlation_id, created_at, updated_at
+- [ ] State transition timeline (visual history of state changes)
+- [ ] Triage sub-task section: linked triage_log entries for this task
+- [ ] Outcome score displayed if present (success/partial/failed/escalated + confidence)
+- [ ] Back navigation to originating list view
+
+**Size:** M
+**Dependencies:** S10.2
+**Blocks:** S10.7
+
+---
+
+### S10.5: Implement triage activity feed
+
+**Description:** Real-time feed of recent triage decisions from the `triage_log` table. Filterable by channel, mode, and decision type. Provides operational visibility into what Amara's triage layer is doing.
+
+**Acceptance Criteria:**
+- [ ] Displays triage decisions in reverse chronological order
+- [ ] Each entry shows: timestamp, decision, confidence, channel, mode, latency_ms
+- [ ] Filter by channel (dropdown)
+- [ ] Filter by mode (dropdown)
+- [ ] Filter by decision type (dropdown)
+- [ ] Updates via WebSocket push for new decisions
+
+**Size:** M
+**Dependencies:** S1.5, S10.1, S10.8
+**Blocks:** S10.6, S10.7
+
+---
+
+### S10.6: Implement undo controls for reversible triage actions
+
+**Description:** Add undo buttons for reversible triage actions (D14): archive, label, and draft_reply are reversible; mark_read is not. The undo control appears inline on the triage feed entry for a brief window after the action.
+
+**Acceptance Criteria:**
+- [ ] Reversible actions (archive, label, draft_reply) show an "Undo" button
+- [ ] Non-reversible actions (mark_read) do not show an undo button
+- [ ] Undo window: button available for 30 seconds after action
+- [ ] Undo triggers the reverse operation and updates the feed entry
+- [ ] Visual distinction between undone and active triage entries
+
+**Size:** M
+**Dependencies:** S10.5
+**Blocks:** S10.7
+
+---
+
+### S10.7: Mobile layout pass
+
+**Description:** Basic responsive CSS to ensure all dashboard views render correctly at 390px viewport width (iPhone 14 baseline). This is not a full mobile UX — PWA, gesture support, and native-like interactions are deferred to Milestone 6.
+
+**Acceptance Criteria:**
+- [ ] All views (task lists, audit log, triage feed, task detail) render without horizontal scroll at 390px
+- [ ] Navigation collapses to a mobile-friendly pattern (hamburger menu or bottom tabs)
+- [ ] Touch targets are at least 44px (iOS HIG minimum)
+- [ ] Text is readable without zooming
+- [ ] No layout-breaking overflow on any view
+
+**Size:** S
+**Dependencies:** S10.2, S10.3, S10.4, S10.5
+**Blocks:** None
+
+---
+
+### S10.8: Dashboard server integration
+
+**Description:** Integrate the dashboard into Amara's runtime as a same-process Gateway HTTP endpoint (D8). Implement WebSocket push for real-time updates instead of polling.
+
+**Acceptance Criteria:**
+- [ ] Dashboard static assets served from Gateway HTTP endpoint
+- [ ] WebSocket endpoint established for push updates
+- [ ] Task state changes pushed to connected dashboard clients
+- [ ] Triage log entries pushed to connected dashboard clients
+- [ ] Dashboard accessible at `http://localhost:<port>/dashboard`
+- [ ] No separate process required — starts with Amara
+
+**Size:** M
+**Dependencies:** S10.1
+**Blocks:** S10.2, S10.3, S10.5
+
+## Story Sequencing
+
+```
+Phase 1:
+  S10.1: Canvas/A2UI scaffolding ──────┐
+                                       │
+Phase 2 (unblocked by Phase 1):       │
+  S10.8: Server integration ◄─────────┘
+
+Phase 3 (unblocked by Phase 2 + cross-epic):
+  S10.2: Task list views ◄───────────── (needs S1.9, S10.1, S10.8)
+  S10.3: Audit log view ◄────────────── (needs S2.6, S10.1, S10.8)
+  S10.5: Triage activity feed ◄──────── (needs S1.5, S10.1, S10.8)
+
+Phase 4 (unblocked by Phase 3):
+  S10.4: Task detail view ◄──────────── (needs S10.2)
+  S10.6: Undo controls ◄─────────────── (needs S10.5)
+
+Phase 5 (all views complete):
+  S10.7: Mobile layout pass ◄────────── (needs S10.2, S10.3, S10.4, S10.5)
+```
 
 ## Dependencies
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ Navigation hub for all Amara documentation and planning.
 |----------|---------|
 | [architecture.md](architecture.md) | System design overview, component diagram |
 | [roadmap.md](roadmap.md) | Sequenced milestones across epics |
+| [milestone-1-plan.md](milestone-1-plan.md) | M1 cross-epic dependencies, critical path, 33 stories |
 
 ## Epics
 

--- a/docs/milestone-1-plan.md
+++ b/docs/milestone-1-plan.md
@@ -1,0 +1,143 @@
+# Milestone 1 — Implementation Plan
+
+Milestone 1 covers Epics 1, 2, 3, and 10: the foundational infrastructure, security contracts, observability layer, and dashboard. This document provides the cross-epic view — dependency map, critical path, and unified story table.
+
+## Unified Story Table
+
+33 stories across 4 epics.
+
+| ID | Title | Size | Epic | Dependencies | Blocks |
+|----|-------|------|------|-------------|--------|
+| S1.1 | Define task schema | S | 1 | — | S1.3, S1.9, S2.5, S3.3, S3.4 |
+| S1.2 | Implement SQLite setup and migration runner | M | 1 | — | S1.3, S1.4, S1.5, S1.6, S2.5, S2.6 |
+| S1.3 | Implement task state machine | M | 1 | S1.1, S1.2 | S1.8, S1.9 |
+| S1.4 | Implement event queue | M | 1 | S1.2, S1.6 | S1.7, S1.8, S2.6 |
+| S1.5 | Define triage_log table schema | S | 1 | S1.2 | S2.5, S3.8, S10.5 |
+| S1.6 | Define event_queue + amara_dlq tables | S | 1 | S1.2 | S1.4, S1.7, S2.5 |
+| S1.7 | Implement poison message detection and DLQ routing | M | 1 | S1.4, S1.6 | — |
+| S1.8 | Write crash-recovery test | M | 1 | S1.3, S1.4 | — |
+| S1.9 | Export and document task CRUD API | S | 1 | S1.3 | S3.4, S10.2 |
+| S2.1 | Define OAuth scopes per channel | S | 2 | — | — |
+| S2.2 | Implement secret storage | S | 2 | — | — |
+| S2.3 | Write log-sanitization test | M | 2 | S3.1 | — |
+| S2.4 | Define PII inventory and retention policy | S | 2 | — | — |
+| S2.5 | Implement delete-my-data 7-step process | L | 2 | S1.1, S1.2, S1.5, S1.6 | — |
+| S2.6 | Define and wire security audit log | M | 2 | S1.2, S1.4 | S2.7, S10.3 |
+| S2.7 | Implement D14 write permission audit logging | M | 2 | S2.6 | — |
+| S2.8 | Document input validation contracts | S | 2 | — | — |
+| S3.1 | Define structured logging standard | S | 3 | — | S2.3, S3.3 |
+| S3.2 | Implement OTLP/OpenTelemetry integration | M | 3 | — | S3.3, S3.7, S3.8 |
+| S3.3 | Implement correlation ID propagation | M | 3 | S1.1, S3.2 | — |
+| S3.4 | Define and implement agent outcome scoring | M | 3 | S1.1, S1.9 | S3.6 |
+| S3.5 | Document failure taxonomy | S | 3 | — | S3.6 |
+| S3.6 | Build eval harness | L | 3 | S3.4, S3.5 | — |
+| S3.7 | Define metrics and their collection points | S | 3 | S3.2 | S3.8 |
+| S3.8 | Implement triage decision metrics | M | 3 | S1.5, S3.2, S3.7 | — |
+| S10.1 | Set up Canvas/A2UI project | M | 10 | — | S10.2, S10.3, S10.5, S10.8 |
+| S10.2 | Implement active/pending/history views | L | 10 | S1.9, S10.1, S10.8 | S10.4, S10.7 |
+| S10.3 | Implement audit log view | M | 10 | S2.6, S10.1, S10.8 | S10.7 |
+| S10.4 | Implement task detail view | M | 10 | S10.2 | S10.7 |
+| S10.5 | Implement triage activity feed | M | 10 | S1.5, S10.1, S10.8 | S10.6, S10.7 |
+| S10.6 | Implement undo controls for reversible triage actions | M | 10 | S10.5 | S10.7 |
+| S10.7 | Mobile layout pass | S | 10 | S10.2, S10.3, S10.4, S10.5 | — |
+| S10.8 | Dashboard server integration | M | 10 | S10.1 | S10.2, S10.3, S10.5 |
+
+### Size Summary
+
+| Size | Count |
+|------|-------|
+| S | 12 |
+| M | 18 |
+| L | 3 |
+| **Total** | **33** |
+
+## Cross-Epic Dependency Map
+
+These are the dependencies that cross epic boundaries — the coordination points where one epic's output is another's input.
+
+| Downstream | Upstream | Reason |
+|-----------|----------|--------|
+| S2.3 | S3.1 | Log sanitization test needs logging standard defined |
+| S2.5 | S1.1, S1.2, S1.5, S1.6 | Delete-my-data must cover all tables |
+| S2.6 | S1.2, S1.4 | Security audit log needs DB + event bus |
+| S2.7 | S2.6 | Write audit extends security audit log |
+| S3.3 | S1.1 | correlation_id field on tasks table |
+| S3.4 | S1.1, S1.9 | Outcome scores stored in Task DB |
+| S3.8 | S1.5 | Triage metrics read from triage_log |
+| S10.2 | S1.9 | Task views read via CRUD API |
+| S10.3 | S2.6 | Audit view reads from audit log tables |
+| S10.5 | S1.5 | Triage feed reads from triage_log |
+
+## Critical Path
+
+The longest dependency chain through the milestone determines the minimum time to completion:
+
+```
+S1.1 + S1.2 (parallel)
+    → S1.3
+        → S1.9
+            → S10.2 (also needs S10.1 → S10.8)
+                → S10.4
+                    → S10.7
+```
+
+**Critical path length:** 6 phases (S1.1/S1.2 → S1.3 → S1.9 → S10.2 → S10.4 → S10.7)
+
+Epic 1 foundations (schema + migration runner) are the single biggest bottleneck. Everything else fans out from there.
+
+## Unified Cross-Epic Dependency Graph
+
+```
+                    ┌─────────────────── MILESTONE 1 ───────────────────┐
+                    │                                                    │
+  PHASE 1           │  S1.1 ─┐    S2.1    S3.1 ───┐    S10.1 ──┐      │
+  (no deps)         │  S1.2 ─┤    S2.2    S3.2 ───┤            │      │
+                    │        │    S2.4    S3.5 ─┐  │            │      │
+                    │        │    S2.8          │  │            │      │
+                    │        │                  │  │            │      │
+  PHASE 2           │  S1.3 ◄┤    S2.3 ◄───────│──┘            │      │
+  (Epic 1 core)     │  S1.5 ◄┤                  │     S10.8 ◄──┘      │
+                    │  S1.6 ◄┘                  │              │       │
+                    │        │                  │              │       │
+  PHASE 3           │  S1.4 ◄┤    S2.6 ◄───────│──┐           │       │
+  (queues + API)    │  S1.9 ◄┘    │             │  │           │       │
+                    │     │       │       S3.3 ◄┘  │           │       │
+                    │     │       │       S3.4 ◄───│───────────│──┐    │
+                    │     │       │       S3.7 ◄┘  │           │  │    │
+                    │     │       │                 │           │  │    │
+  PHASE 4           │  S1.7 ◄┐    S2.7 ◄┘          │  S10.2 ◄──┤──┘    │
+  (advanced)        │  S1.8 ◄┘                S3.6 ◄┘  S10.3 ◄──┤      │
+                    │                         S3.8     S10.5 ◄──┘      │
+                    │                                      │           │
+  PHASE 5           │              S2.5 ◄── (Epic 1)  S10.4 ◄┘        │
+  (integration)     │                                  S10.6 ◄┘        │
+                    │                                      │           │
+  PHASE 6           │                                  S10.7 ◄─────────│
+  (polish)          │                                                  │
+                    └──────────────────────────────────────────────────┘
+
+  Legend: ◄── dependency    ─┐ fan-out    ◄┘ fan-in
+```
+
+## Open Question Resolutions
+
+All 5 open questions from Milestone 1 epics have been resolved:
+
+| # | Question | Resolution | Epic |
+|---|----------|-----------|------|
+| 1 | Migration tool: raw SQL, library, or hand-rolled? | Raw SQL files + hand-rolled runner (~50 lines TS, `schema_version` table) | 1 |
+| 2 | Eval harness interface? | Separate `*.eval.ts` files + `npm run eval` | 3 |
+| 3 | Evals in `node --test` or separate? | Same runner, separate command (`npm test` vs `npm run eval`) | 3 |
+| 4 | Failure taxonomy ownership? | Epic 3 defines base union type; Epics 5/9 extend | 3 |
+| 5 | Outcome score thresholds? | Config-driven with documented defaults (>0.95 destructive, >0.7 escalation) | 3 |
+
+## Implementation Order Recommendation
+
+For a single implementer, the recommended sequence maximizes parallelism within each phase while respecting all dependencies:
+
+1. **Start:** S1.1 + S1.2 + S3.1 + S3.2 + S3.5 + S10.1 + all S2 docs (S2.1, S2.2, S2.4, S2.8)
+2. **After Epic 1 foundations:** S1.3 + S1.5 + S1.6 + S2.3 + S10.8
+3. **After state machine + schemas:** S1.4 + S1.9 + S2.6 + S3.3 + S3.4 + S3.7
+4. **After queues + API:** S1.7 + S1.8 + S2.7 + S3.6 + S3.8 + S10.2 + S10.3 + S10.5
+5. **After views:** S2.5 + S10.4 + S10.6
+6. **Final:** S10.7 (mobile pass after all views complete)


### PR DESCRIPTION
## Summary

- Resolve all 5 open questions across Epics 1 and 3 (migration tool, eval harness, failure taxonomy, evals separation, outcome thresholds)
- Elaborate 33 stories (9+8+8+8) across Epics 1, 2, 3, 10 with descriptions, acceptance criteria, sizing, and dependency mapping
- Create `docs/milestone-1-plan.md` with cross-epic dependency map, critical path analysis, and unified story table

## Test plan

- [ ] Verify all 5 open questions marked `[x]` resolved in Key Decisions sections
- [ ] Count stories: 9 + 8 + 8 + 8 = 33 total, each with description, AC, size, deps
- [ ] `docs/milestone-1-plan.md` exists with cross-epic dependency table
- [ ] Each epic has `## Story Sequencing` section
- [ ] `docs/index.md` links to milestone-1-plan.md
- [ ] No code changes — documentation only

Fixes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)