### PR TITLE
docs: update architecture docs for OpenClaw v2026.3.2-beta.1

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Amara is an opinionated personal assistant built on top of **OpenClaw** (selected as host platform — see [Epic 0, Section 1.5](epics/00-integration-architecture.md#15-platform-selection)). She operates in two modes:
+Amara is an opinionated personal assistant built on top of **OpenClaw** (minimum version: v2026.3.2-beta.1 — [D15](epics/00-integration-architecture.md#10-decision-log); selected as host platform — see [Epic 0, Section 1.5](epics/00-integration-architecture.md#15-platform-selection)). She operates in two modes:
 
 1. **Monitored mode** — passively observes ALL communications (full email inbox, all WhatsApp conversations, full calendar). A fast triage layer makes autonomous decisions on most messages (archive spam, label, mark read, note context) without entering the full orchestrator pipeline.
 2. **Direct mode** — the user talks to Amara specifically (dedicated thread, specific address). All messages enter the full orchestrator pipeline for planning and delegation.
@@ -75,13 +75,13 @@ Amara is a **manager, not a doer**. She runs on a fast model and coordinates spe
 
 ### OpenClaw (Host Platform)
 
-The plugin host that provides channel adapters (WhatsApp via Baileys, Telegram, Gmail via `gog` with Pub/Sub push, Calendar via `gog` with full CRUD, iMessage via BlueBubbles, plus 15+ more), webhook lifecycle management, Docker sandboxing (per-session with security controls), OTLP observability (17+ metrics), and a modular plugin SDK (channels, tools, hooks, commands, services, providers). Amara runs as a set of tool plugins within the OpenClaw Gateway process.
+The plugin host that provides channel adapters (WhatsApp via Baileys, Telegram, Gmail via `gog` with Pub/Sub push, Calendar via `gog` with full CRUD, iMessage via BlueBubbles, plus 15+ more), webhook lifecycle management, Docker sandboxing (per-session with security controls), OTLP observability (17+ metrics), and a modular plugin SDK (channels, tools, hooks, commands, services, providers). Amara runs as a set of tool plugins within the OpenClaw Gateway process. **v2026.3.2-beta.1 version-gated features:** `message:preprocessed` hook, `sessionKey` in lifecycle hooks, `onAgentEvent`/`onSessionTranscriptUpdate` runtime events, `requestHeartbeatNow()`, session attachments, `channelRuntime` context, `transcribeAudioFile()` API, SecretRef expansion (64 targets), ACP dispatch default-enabled. See [Section 1.6](epics/00-integration-architecture.md#16-minimum-openclaw-version).
 
 **Selected over** Hermes Agent, Moltworker, and others. See [Platform Selection rationale](epics/00-integration-architecture.md#15-platform-selection).
 
 ### Amara Triage Layer (Epic 1, Epic 5)
 
-The fast decision engine between normalization and orchestrator. Classifies every inbound event into one of two modes:
+The fast decision engine between normalization and orchestrator. The `message:preprocessed` hook (v2026.3.2-beta.1, beta — verify event shape on stable release) is a candidate interception point for this layer, providing early access to messages before standard processing. Classifies every inbound event into one of two modes:
 
 - **Direct mode** — user is talking to Amara. All events pass through to the event queue and orchestrator.
 - **Monitored mode** — passive observation. The triage layer makes autonomous silent actions: archive spam, label, mark read, draft replies (<200ms rules-based or <2s fast model). Triage never sends outbound messages. ~10% of monitored messages escalate to orchestrator.
@@ -90,7 +90,7 @@ All triage decisions are logged to the `triage_log` table for Dashboard visibili
 
 ### Amara Orchestrator (Epic 5)
 
-The always-on brain. Receives direct-mode events and escalated monitored-mode events via the event queue. Acknowledges immediately, breaks work into tasks, delegates to specialist agents, and monitors progress. Runs on a fast model. Lives in-process as an OpenClaw tool plugin.
+The always-on brain. Receives direct-mode events and escalated monitored-mode events via the event queue. Acknowledges immediately, breaks work into tasks, delegates to specialist agents, and monitors progress. Runs on a fast model. Lives in-process as an OpenClaw tool plugin. Delegation tracking leverages `onAgentEvent` and `onSessionTranscriptUpdate` (v2026.3.2-beta.1, beta — verify on stable) for real-time progress signals. Note: `onSessionTranscriptUpdate` data is PII-bearing and subject to Epic 2 retention policy.
 
 ### Task State Machine (Epic 1)
 
@@ -152,7 +152,7 @@ Task visibility UI leveraging OpenClaw's Canvas/A2UI feature. Served via the Gat
 | Triage decision latency (P95) | < 200 ms |
 | Triage throughput | ≥ 500 messages/day |
 | Acknowledgment latency (P95) | < 1000 ms (direct + escalated events) |
-| Agent response (P95) | < 45 s (with interim updates every 15s) |
+| Agent response (P95) | < 45 s (with interim updates every 15s via `onSessionTranscriptUpdate` — v2026.3.2-beta.1, beta) |
 | Task persistence | RPO = 0 for acknowledged tasks (process crash/OOM; see [Epic 0 caveats](epics/00-integration-architecture.md#8-non-functional-requirements)) |
 | Availability | ≥ 95% uptime (no formal SLA) |
 | Concurrent tasks | Max 10 |

--- a/docs/epics/00-integration-architecture.md
+++ b/docs/epics/00-integration-architecture.md
@@ -101,6 +101,58 @@ Two platforms survived initial screening as viable hosts for Amara: **OpenClaw**
 
 > See Decision Log entry **D0** for the formal decision record.
 
+## 1.6. Minimum OpenClaw Version
+
+**Required version: `v2026.3.2-beta.1` or later** (Decision D15)
+
+OpenClaw v2026.3.2-beta.1 (released March 3, 2026) introduces features that directly address capabilities Amara planned to build custom workarounds for. Pinning to this version prevents implementing custom solutions for features that are now native.
+
+**Key features requiring this version:**
+
+- `message:preprocessed` hook — candidate triage interception point (beta-caveat)
+- `sessionKey` in lifecycle hooks — native session identity correlation (beta-caveat)
+- `onAgentEvent` / `onSessionTranscriptUpdate` — delegation tracking signals (beta-caveat)
+- `requestHeartbeatNow()` — on-demand scheduler trigger (beta-caveat)
+- Session attachments — file passing between agents (beta-caveat)
+- `channelRuntime` on gateway context — channel state inspection (beta-caveat)
+- `transcribeAudioFile()` — audio transcription API (beta-caveat, P2 scope)
+- SecretRef expansion (64 targets, fail-fast validation) — stable
+- ACP dispatch default enabled — stable
+
+### Breaking Changes
+
+| Change | Impact | Migration |
+|--------|--------|-----------|
+| `tools.profile` default changed | Agent bundles without explicit `tools.profile` will use the new default, potentially breaking tool access | All agent bundles MUST declare `tools.profile` explicitly (see Epic 4 schema) |
+| `registerHttpHandler()` removed | Replaced by `registerHttpRoute()` — different API signature | Update all HTTP route registrations to use `registerHttpRoute()` (see Epic 10 S10.8) |
+| Node.js >=22.12 enforced | Previous minimum was >=22 | Update all dev environments and CI to Node.js >=22.12 |
+| ACP dispatch default enabled | `agentToAgent` delegation now uses ACP by default | Verify delegation behavior; explicit opt-out available if needed |
+
+### Critical Upstream Bug Fixes
+
+| Fix | Impact on Amara |
+|-----|----------------|
+| Session lock PID recycling fix | Prevents stale lock contention in long-running orchestrator sessions |
+| Hook duplicate dispatch fix | Prevents double-processing of events in triage layer |
+| `llm_input` context parity | Ensures consistent context available across all hook types |
+| Cron/heartbeat fixes | Improves reliability of Amara's heartbeat-driven scheduler |
+
+### Migration Checklist: `tools.profile`
+
+- [ ] Audit all agent bundle YAML files for `tools.profile` field
+- [ ] Add explicit `tools.profile` to any bundle missing it
+- [ ] Verify tool access works correctly after migration
+- [ ] Update bundle schema validation to require `tools.profile`
+
+### Migration Checklist: `registerHttpRoute()`
+
+- [ ] Search codebase for `registerHttpHandler` references
+- [ ] Replace all calls with `registerHttpRoute()` equivalent
+- [ ] Verify HTTP endpoints function correctly after migration
+- [ ] Update any documentation referencing `registerHttpHandler`
+
+> **Review trigger:** Revisit D15 when OpenClaw v2026.3.2 stable is released. Verify all beta-caveat features are stable and adjust documentation accordingly.
+
 ## 2. OpenClaw Capabilities Matrix
 
 > Status legend:
@@ -116,9 +168,9 @@ Two platforms survived initial screening as viable hosts for Amara: **OpenClaw**
 | Gmail outbound send | native | `gog gmail send`, [`skills/gog/SKILL.md`](https://github.com/openclaw/openclaw/blob/main/skills/gog/SKILL.md) | Full send API: `--body` (plain text), `--body-html` (HTML), `--body-file` (file/stdin), `--reply-to-message-id` (thread replies). Draft create/send via `gog gmail drafts create/send`. |
 | Calendar read | native | `gog calendar events`, [`skills/gog/SKILL.md`](https://github.com/openclaw/openclaw/blob/main/skills/gog/SKILL.md) | `gog calendar events <calendarId> --from <iso> --to <iso>`. Full event listing with date ranges. |
 | Calendar write | native | `gog calendar create/update`, [`skills/gog/SKILL.md`](https://github.com/openclaw/openclaw/blob/main/skills/gog/SKILL.md) | `gog calendar create` with `--summary`, `--from`, `--to`, `--event-color` (11 color IDs). `gog calendar update` for modifications. No invite management or RSVP (Amara gap). |
-| Plugin hook event system | native | [`src/plugins/types.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/types.ts) | 27 hook types: `message_received`, `message_sending`, `message_sent`, `session_start/end`, `before/after_tool_call`, `subagent_spawning/spawned/ended`, `gateway_start/stop`, `llm_input/output`, etc. Priority-based ordering. No centralized event bus (OpenClawBus RFC #15016 still RFC). |
+| Plugin hook event system | native | [`src/plugins/types.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugins/types.ts) | 31 hook types (updated for v2026.3.2-beta.1): `message_received`, `message_sending`, `message_sent`, `message:preprocessed` (beta — verify on stable), `session_start/end`, `before/after_tool_call`, `subagent_spawning/spawned/ended`, `gateway_start/stop`, `llm_input/output`, `onAgentEvent` (beta), `onSessionTranscriptUpdate` (beta), etc. `sessionKey` available in session lifecycle hooks (beta). Priority-based ordering. No centralized event bus (OpenClawBus RFC #15016 still RFC). |
 | Persistent storage | native | [`extensions/memory-core/`](https://github.com/openclaw/openclaw/tree/main/extensions/memory-core), [`extensions/memory-lancedb/`](https://github.com/openclaw/openclaw/tree/main/extensions/memory-lancedb) | Dual backend: SQLite + sqlite-vec (cosine vector search + FTS5 BM25 keyword) and LanceDB (OpenAI embeddings). Auto-capture on messages, auto-recall on context. |
-| Auth / secret management | native | [`src/agents/auth-profiles/`](https://github.com/openclaw/openclaw/tree/main/src/agents/auth-profiles) | Per-agent workspace scoping. Tokens stored at `~/.openclaw/agents/{agentId}/agent/auth-profiles.json`. Supports `SecretRef` indirection. Legacy `auth.json` auto-migrated. Fallback chain: agent-specific → main agent → legacy. |
+| Auth / secret management | native | [`src/agents/auth-profiles/`](https://github.com/openclaw/openclaw/tree/main/src/agents/auth-profiles) | Per-agent workspace scoping. Tokens stored at `~/.openclaw/agents/{agentId}/agent/auth-profiles.json`. Supports `SecretRef` indirection with 64 target expansion and fail-fast validation (v2026.3.2-beta.1). Legacy `auth.json` auto-migrated. Fallback chain: agent-specific → main agent → legacy. |
 | Webhook lifecycle (register, renew, verify) | native | [`src/hooks/gmail-watcher.ts`](https://github.com/openclaw/openclaw/blob/main/src/hooks/gmail-watcher.ts), [`src/gateway/hooks.ts`](https://github.com/openclaw/openclaw/blob/main/src/gateway/hooks.ts) | Gmail: auto-registration via `gog gmail watch start`, auto-renewal every 12h, verification via `X-Gog-Token` header. Gateway hooks: webhook endpoint at `/hooks/*` with template-based routing, auth (Bearer/X-OpenClaw-Token), rate limiting (20 failed/60s → 429). |
 | Retry primitives | native | [`src/infra/retry.ts`](https://github.com/openclaw/openclaw/blob/main/src/infra/retry.ts), [`src/infra/backoff.ts`](https://github.com/openclaw/openclaw/blob/main/src/infra/backoff.ts) | Exponential backoff with jitter, configurable attempts/min/max delay. Per-channel tuning (Discord: 3 attempts 500-30000ms; Telegram: 3 attempts 400-30000ms + `retry_after` extraction). Circuit breaker for Telegram 401s (suspends after 10 consecutive failures). |
 | Deduplication / idempotency | native | [`src/infra/dedupe.ts`](https://github.com/openclaw/openclaw/blob/main/src/infra/dedupe.ts), [`src/plugin-sdk/persistent-dedupe.ts`](https://github.com/openclaw/openclaw/blob/main/src/plugin-sdk/persistent-dedupe.ts) | Dual-layer: in-memory (TTL + LRU, 20-min TTL, 5000 entries for web inbound) + persistent disk (file-locked JSON with exponential backoff locking). Inflight promise deduplication. Used for WhatsApp, Discord, Feishu webhooks. **Amara still needs cross-channel task-level dedup** (same request via WhatsApp + email → single task). |
@@ -128,6 +180,12 @@ Two platforms survived initial screening as viable hosts for Amara: **OpenClaw**
 | Canvas / A2UI | native | [`src/canvas-host/`](https://github.com/openclaw/openclaw/tree/main/src/canvas-host), [`vendor/a2ui/`](https://github.com/openclaw/openclaw/tree/main/vendor/a2ui) | Agent-generated HTML served via Gateway. A2UI spec with Angular + Lit renderers. Cross-platform action bridge (iOS/Android/Web). Live reload in dev mode. File serving with range requests. |
 | Docker sandboxing | native | [`src/agents/sandbox/`](https://github.com/openclaw/openclaw/tree/main/src/agents/sandbox), `Dockerfile.sandbox` | Per-session containers (scope: session/agent/shared). Workspace access: none/ro/rw. Security: blocked bind sources (`docker.sock`, `/etc`, `/proc`, `/sys`, `/dev`), capability dropping, seccomp/AppArmor profiles, network isolation (bridge/none/custom). Resource limits: pids, memory, CPU, ulimits. |
 | Multi-provider LLM | native | [Model providers docs](https://docs.openclaw.ai/concepts/model-providers) | 13+ built-in (OpenAI, Anthropic, Gemini, OpenRouter, Groq, etc.) + local (Ollama, vLLM, LM Studio). Two API types: openai-completions, anthropic-messages. |
+| Audio transcription (STT) | native | v2026.3.2-beta.1 `transcribeAudioFile()` API | (beta — verify on stable) Transcribes audio files to text. P2 enhancement for Amara — voice message handling is not v1 scope. |
+| PDF analysis | native | v2026.3.2-beta.1 | Native PDF content extraction and analysis capabilities. |
+| CLI config validation | native | v2026.3.2-beta.1 `openclaw config validate --json` | Machine-readable config validation output. Useful for onboarding and deployment verification (Epic 11). |
+| Ollama embeddings | native | v2026.3.2-beta.1 | Local embedding generation via Ollama provider. Extends vector search options beyond OpenAI embeddings. |
+| Session attachments | native | v2026.3.2-beta.1 | (beta — verify on stable) File passing between agent sessions. Enables structured file handoff in orchestrator delegation. |
+| Channel runtime context | native | v2026.3.2-beta.1 `channelRuntime` on gateway context | (beta — verify on stable) Runtime state inspection for channel adapters. Useful for health checks and normalization layer state access. |
 
 ## 3. Gap Analysis
 
@@ -137,9 +195,9 @@ Two platforms survived initial screening as viable hosts for Amara: **OpenClaw**
 
 | Gap | Proposed Owner | Downstream Epic | Notes |
 |---|---|---|---|
-| Triage layer (two-mode architecture) | Amara core | Epic 1, Epic 5 | Fast decision engine between normalization and orchestrator. Routes direct-mode messages straight to queue; evaluates monitored-mode messages on a spectrum (autonomous action → escalate). Must handle high throughput (hundreds of messages/day) with <200ms decision latency. See Section 7 for triage decision spectrum. |
+| Triage layer (two-mode architecture) | Amara core | Epic 1, Epic 5 | Fast decision engine between normalization and orchestrator. Routes direct-mode messages straight to queue; evaluates monitored-mode messages on a spectrum (autonomous action → escalate). Must handle high throughput (hundreds of messages/day) with <200ms decision latency. See Section 7 for triage decision spectrum. **v2026.3.2-beta.1 delta:** `message:preprocessed` hook (beta — verify on stable) provides a native interception point before message processing; may serve as a cleaner hook for the triage layer. **Amara still builds:** mode routing logic, rules engine, action engine, triage log. **Priority unchanged (P0):** hook provides interception point only, not triage logic. |
 | Task state machine | Amara core | Epic 1 | SQLite-backed states: `pending → in_progress → blocked → complete \| failed`. OpenClaw has no task lifecycle concept. |
-| Follow-up / re-check scheduler | Amara core | Epic 1 | OpenClaw cron exists but is session-isolated. Need task-aware scheduling that re-checks in-progress tasks and re-queues stalled work. |
+| Follow-up / re-check scheduler | Amara core | Epic 1 | OpenClaw cron exists but is session-isolated. Need task-aware scheduling that re-checks in-progress tasks and re-queues stalled work. **v2026.3.2-beta.1 delta:** `requestHeartbeatNow()` (beta — verify on stable) provides an on-demand trigger mechanism for immediate re-checks. **Amara still builds:** scheduling logic (reading Task DB, deciding what to re-check, stall detection thresholds). **Priority unchanged (P0):** trigger mechanism only, not scheduling logic. |
 | Cross-channel task-level idempotency | Amara core | Epic 1 | OpenClaw has message-level dedup (dual-layer: memory + persistent disk) per channel. Amara needs *task*-level dedup across channels — same request via WhatsApp and email must not create duplicate tasks. Requires semantic matching, not just message ID dedup. |
 | Event reliability (DB-backed queue) | Amara core | Epic 1 | OpenClaw plugin hooks are synchronous and don't provide replay on failure. Amara needs at-least-once delivery for task-critical events. SQLite WAL-mode queue with crash recovery. |
 
@@ -150,13 +208,13 @@ Two platforms survived initial screening as viable hosts for Amara: **OpenClaw**
 | Orchestrator / planner | Amara core | Epic 5 | The always-on brain. OpenClaw provides agent sessions but no orchestration layer. Amara must build: intake → plan → delegate → track → complete. |
 | Agent registry | Amara core | Epic 4 | YAML + markdown bundles defining specialist agents. OpenClaw multi-agent routing is per-channel, not per-capability. Amara needs capability-based routing. |
 | Structured I/O contract | Amara core | Epic 4 | Agents need typed input/output schemas for task assignments and results. OpenClaw provides JSON transport (D7), but Amara must define the semantic contract: task assignment format, result report format, and schema versioning. |
-| Multi-agent coordination | Amara core | Epic 5 | Parallel task execution, result aggregation, conflict resolution. OpenClaw `agentToAgent` is basic point-to-point. |
+| Multi-agent coordination | Amara core | Epic 5 | Parallel task execution, result aggregation, conflict resolution. OpenClaw `agentToAgent` is basic point-to-point. **v2026.3.2-beta.1 delta:** `onAgentEvent` and `onSessionTranscriptUpdate` (beta — verify on stable) provide runtime tracking signals for delegation progress and transcript changes. **Amara still builds:** coordination logic, conflict resolution, result aggregation, parallel task management. **Priority unchanged (P1):** signals aid monitoring, not coordination logic. |
 | Human escalation loop | Amara core | Epic 6 | When blocked or ambiguous, route to human for decision. OpenClaw has no escalation concept. |
 | Gmail enhanced compose | Amara service | Epic 8 | `gog gmail send` provides text, HTML, reply-to, and draft support natively. Amara needs: attachment handling (beyond `--body-file`), template-based compose, batch operations. Build as thin wrapper over `gog`. |
 | Gmail message management (triage actions) | Amara service | Epic 8 | Triage layer needs `gmail.modify` scope to archive, label, and mark messages as read autonomously. `gog` provides send/compose but not inbox management. Amara must call Gmail API directly for modify operations (archive, add/remove labels, mark read/unread). |
 | Calendar event model | Amara service | Epic 8 | `gog` provides full CRUD (list/create/update with colors). v1 scope: conflict detection and scheduling suggestions. v2 scope: invite management, RSVP (requires direct Calendar API calls beyond `gog`). Build as analysis layer on top of native `gog` calendar data. |
 | Dashboard UI | Amara service | Epic 10 | Task visibility, audit log, triage activity feed. Leverage OpenClaw Canvas/A2UI as the rendering surface. Core dashboard (task views, audit log, triage log) in Milestone 1 for early visibility. Mobile-optimized layout deferred to Milestone 6 polish. |
-| Channel adapter normalization | Amara core | Epic 7 | OpenClaw channels emit different event shapes. Amara needs a common envelope format for the orchestrator. Channel binding config must support two modes: "monitor entire account" (monitored mode) vs "this thread is Amara's direct line" (direct mode). |
+| Channel adapter normalization | Amara core | Epic 7 | OpenClaw channels emit different event shapes. Amara needs a common envelope format for the orchestrator. Channel binding config must support two modes: "monitor entire account" (monitored mode) vs "this thread is Amara's direct line" (direct mode). **v2026.3.2-beta.1 delta:** `channelRuntime` on gateway context (beta — verify on stable) provides runtime state inspection for channel adapters. **Amara still builds:** AmaraEvent envelope conversion, channel binding configuration, mode field logic. **Priority unchanged (P1):** `channelRuntime` aids state inspection, not envelope conversion. |
 | Cross-channel threading / reply context | Amara core | Epic 7, Epic 8 | How are reply chains and thread context preserved across channels in the AmaraEvent envelope? Each channel has different threading models (WhatsApp: quoted message, Gmail: thread ID, Telegram: reply_to_message_id). Must be resolved before normalization layer. |
 
 ### P2 — Enhancements
@@ -193,7 +251,7 @@ Two platforms survived initial screening as viable hosts for Amara: **OpenClaw**
 | Gmail enhanced tools | OpenClaw tool plugin | Amara | low | planned (Epic 8) | Thin wrapper over native `gog gmail` — adds attachment handling, template compose, batch operations. Core send/receive is native. |
 | Calendar analysis tools | OpenClaw tool plugin | Amara | medium | planned (Epic 8) | v1: conflict detection, scheduling suggestions on native `gog calendar` CRUD. v2: invite management, RSVP (requires direct Calendar API). |
 | Gmail message management | OpenClaw tool plugin | Amara | low | planned (Epic 8) | Thin wrapper over Gmail API for inbox management — archive, label, mark read/unread. Required by triage layer for autonomous actions. Uses `gmail.modify` scope. |
-| Normalization layer | Amara internal | Amara | low | planned (Epic 7) | Converts channel events to common envelope. Too Amara-specific to extract. |
+| Normalization layer | Amara internal | Amara | low | planned (Epic 7) | Converts channel events to common envelope. Too Amara-specific to extract. Note: `channelRuntime` (v2026.3.2-beta.1, beta) may reduce extraction cost by providing runtime state inspection natively. |
 | Triage layer | Amara internal | Amara | low | planned (Epic 1, Epic 5) | Mode routing + fast triage + autonomous action engine. Core to Amara's two-mode architecture. Not extractable. |
 | Task state machine | Amara internal | Amara | low | planned (Epic 1) | Core to Amara's identity. Not extractable. |
 | Orchestrator | Amara internal | Amara | low | planned (Epic 5) | Amara's brain. Not extractable. |
@@ -331,6 +389,8 @@ Single-process means a crash in any plugin takes down the Gateway. Mitigations:
 ## 7. Data and Control Flows
 
 Amara operates in two modes. **Direct mode** is for messages explicitly addressed to Amara (dedicated conversation thread, specific email address). **Monitored mode** is for passive observation of all communications (full inbox, all group chats). The triage layer routes between them.
+
+> **v2026.3.2-beta.1 note:** The `message:preprocessed` hook (beta — verify event shape on stable release) may provide a cleaner interception point for the triage layer than the current `message_received` hook. The hook fires before standard message processing, which aligns with triage's need to intercept early. Current diagrams remain valid — the hook is an implementation optimization, not a topology change. Evaluate during Epic 7 implementation.
 
 ### Direct Mode: User → Amara → Response
 
@@ -618,20 +678,21 @@ Amara monitors all communications across all channels. The triage layer makes a 
 | D4 | Channel strategy — WhatsApp | Use OpenClaw native Baileys adapter | Build custom adapter, use Meta Cloud API directly | Baileys adapter is battle-tested in OpenClaw. No reason to duplicate effort. Meta Cloud API requires business verification. | Dependent on Baileys library maintenance. No official WhatsApp support (Baileys reverse-engineers Web protocol). Acceptable risk for personal use. |
 | D5 | Channel strategy — Gmail | Use native `gog` Gmail integration + thin Amara enhancement layer | Build from scratch with Gmail API, use IMAP | `gog` provides full-featured Gmail: Pub/Sub push inbound (`gog gmail watch serve`), send/reply/draft outbound (`gog gmail send`), OAuth2 with auth-profiles. Amara adds: attachment handling, template compose, batch operations. No need to reimplement OAuth or push infrastructure. | Tied to `gog` CLI's API surface. Must monitor for breaking changes. Gmail Pub/Sub requires GCP project setup + Tailscale or equivalent tunnel. |
 | D6 | Channel strategy — Calendar | Use native `gog` Calendar integration + Amara analysis layer | Build from scratch with Google Calendar API | `gog` provides full Calendar CRUD: list events with date ranges, create/update with color support. Amara adds: conflict detection, invite management, scheduling suggestions. These are analysis features on top of native data access. | Tied to `gog` CLI's API surface. Calendar color IDs are Google-specific (1-11). No invite/RSVP in `gog` — Amara must call Calendar API directly for those. |
-| D7 | Inter-agent communication protocol | OpenClaw `agentToAgent` transport + Amara structured protocol | Custom WebSocket protocol, shared SQLite table, filesystem | OpenClaw provides the transport (JSON with schema validation). Amara defines the contract: typed task assignments, result reports, status updates. Avoids building transport layer. | Must define and version the protocol schema. Agent-to-agent requires explicit allowlisting in OpenClaw config. |
+| D7 | Inter-agent communication protocol | OpenClaw `agentToAgent` transport + Amara structured protocol | Custom WebSocket protocol, shared SQLite table, filesystem | OpenClaw provides the transport (JSON with schema validation). Amara defines the contract: typed task assignments, result reports, status updates. Avoids building transport layer. | Must define and version the protocol schema. Agent-to-agent requires explicit allowlisting in OpenClaw config. **v2026.3.2-beta.1 update:** ACP dispatch is now default-enabled — `agentToAgent` uses ACP by default. Verify delegation behavior; explicit opt-out available if needed. |
 | D8 | Dashboard hosting | OpenClaw Canvas/A2UI (served via Gateway) | Separate Express/Fastify server, static site, Electron app | Canvas provides agent-generated HTML served at Gateway's HTTP endpoint. No separate process, no CORS issues, no additional port. Mobile-friendly if properly designed. | Tied to Canvas API surface (relatively new feature). Limited to what A2UI can render. If Canvas proves too limiting, fall back to separate server (low migration cost). |
 | D9 | Secret management | Delegate to OpenClaw's existing auth-profiles mechanism | Vault, dotenv, OS keychain, custom encrypted store | OpenClaw handles OAuth tokens and API keys via `auth-profiles.json` per-agent with `SecretRef` indirection and fallback chain (agent → main → legacy). Amara adds no new secret types. OpenClaw has a built-in `openclaw security audit` CLI for checking filesystem permissions, sandbox config, and secret exposure. | Secrets at `~/.openclaw/agents/{agentId}/agent/auth-profiles.json`. Must ensure directory permissions are correct (0700). Tokens stored in plaintext JSON — encrypt at rest is a future enhancement. No centralized secret rotation — manual process. |
 | D10 | Agent registry format | File-based YAML + markdown bundles (Amara-owned) | Database-backed, OpenClaw plugin registry, API-based | Version-controllable (git), human-readable, hot-reloadable (watch filesystem). Aligns with Hermes SKILL.md concept. No database dependency for agent definitions. | Must implement file watcher for hot-reload. YAML parsing adds startup cost (negligible at expected scale). Schema validation needed to prevent malformed bundles. |
 | D11 | Channel normalization approach | Thin Amara layer converting channel events to common envelope | OpenClaw middleware, per-channel adapters with no common format | Common envelope format enables channel-agnostic orchestration. Thin layer minimizes maintenance. OpenClaw handles transport; Amara handles semantics. | Must define and maintain the AmaraEvent schema. New channels require a normalization mapping. Envelope must be extensible for channel-specific metadata. Envelope includes `mode` field (`monitored` \| `direct`) set by channel binding configuration (D13). |
 | D12 | Memory architecture | Use OpenClaw native memory + Amara Task DB for task context | Custom memory system inspired by Hermes multi-level, replace OpenClaw memory entirely | OpenClaw's memory (SQLite + vector + FTS5) is capable. Amara's task-specific context lives in Task DB. No need to duplicate memory infrastructure. Incorporate Hermes insights (USER.md, SOUL.md layering) as future enhancement. | Two sources of context: OpenClaw memory (conversation) and Amara Task DB (task state). Orchestrator must query both. Future: consider adding USER.md-style profile for personalization. |
 | D13 | Two-mode architecture (passive monitoring + direct conversation) | Triage layer between normalization and orchestrator; two AmaraEvent modes (`monitored` and `direct`) | Single-pipeline (all messages through orchestrator), Separate monitoring service (out-of-process) | Amara must monitor ALL communications (full inbox, all WhatsApp conversations, full calendar) — not just messages addressed to her. Most messages (~90%+) need fast autonomous actions (archive spam, label, mark read), not full orchestrator pipeline. Single pipeline can't handle the throughput/latency requirements. Separate service adds deployment complexity unnecessarily for a single-process architecture. Triage layer in-process keeps latency low (<200ms) and shares access to config/state. | Must implement triage rules + tiny model. Must add `gmail.modify` OAuth scope. Triage log adds write volume to Task DB. Some autonomous actions are reversible (unarchive, remove label) but others may not be (mark as read loses the "unread" signal). Reversible actions should support undo via Dashboard. All actions require high-confidence thresholds regardless. Must define channel binding model (account-level monitoring vs thread-level direct). |
+| D15 | Minimum OpenClaw version pin | v2026.3.2-beta.1 | Previous stable release, wait for stable v2026.3.2 | v2026.3.2-beta.1 introduces features that directly address Amara's planned workarounds: `message:preprocessed` hook, `sessionKey` correlation, `onAgentEvent`/`onSessionTranscriptUpdate` tracking, `requestHeartbeatNow()`, session attachments, `channelRuntime`, `transcribeAudioFile()`, SecretRef expansion (64 targets), ACP dispatch default, and critical bug fixes (session lock PID recycling, hook duplicate dispatch). Waiting for stable release would delay implementation of all downstream epics. Beta risk is acceptable for development (not production). | All downstream epics must target this version minimum. Breaking changes require migration (see Section 1.6). **Review trigger:** Revisit when v2026.3.2 stable ships — verify all beta-caveat features are stable. **Rollback plan:** Revert to previous stable release. Features lost: `sessionKey` correlation (Epic 3 must use custom correlation), `message:preprocessed` hook (Epic 7 uses `message_received`), `onAgentEvent` tracking (Epic 5 must poll for delegation status), session attachments (Epic 9 uses alternative file passing), `requestHeartbeatNow()` (Epic 6 uses interval-only scheduling). Amara must implement custom alternatives for these capabilities. |
 | D14 | Channel write permissions | Visibility ≠ write permission. Monitored channels allow read + silent triage actions (archive, label, mark read, draft) but no outbound messaging by default. Sending messages requires explicit authorization (per-instruction grant or standing rule). Triage layer structurally cannot send messages. | Allow triage to auto-reply, Allow write in all monitored channels by default | Real-world failure mode: opening WhatsApp monitoring caused the agent to respond in every conversation. Monitored channels must be safe-by-default (read + silent triage actions, no outbound messaging). User controls message-sending access explicitly. Per-instruction grants are scoped to a single orchestrator task and target a specific channel/thread. Standing rules are persistent but audited. Grant schema details (max messages, retry semantics, expiry) deferred to Epic 5 orchestrator design. | Must implement authorization check in orchestrator outbound path. Must store standing rules in `~/.amara/config.yaml`. Must audit every outbound message with grant type. Notification routing: Amara never injects messages into monitored channels to notify the user — notifications go to the direct channel or Dashboard. |
 
 ## 11. Risks and Mitigations
 
 | # | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|---|
-| R1 | OpenClaw governance transition disrupts development | medium | high | Pin to known-good release tag. Monitor foundation transition. Maintain fork capability. All Amara code is in plugins that could migrate to another host. |
+| R1 | OpenClaw governance transition disrupts development | medium | high | Pin to v2026.3.2-beta.1 (D15). Monitor foundation transition. Maintain fork capability. All Amara code is in plugins that could migrate to another host. Beta-from-uncertain-governance compounds the risk — see R14. |
 | R2 | `gog` skill API surface changes or is deprecated | medium | medium | Amara wraps `gog` with its own tool plugins (D5, D6). If `gog` breaks, replace the inner implementation without changing Amara's interface. |
 | R3 | Baileys library breaks (WhatsApp protocol change) | medium | high | This affects all Baileys users, not just Amara. Community will fix quickly (large user base). Amara can temporarily disable WhatsApp channel without losing other channels. |
 | R4 | Canvas/A2UI proves too limiting for Dashboard | low | medium | Dashboard core is in Milestone 1 (early visibility). If Canvas is insufficient, fall back to a separate web server (Express/Fastify). Low migration cost — Amara owns the UI logic. Mobile polish deferred to Milestone 6. |
@@ -643,6 +704,7 @@ Amara monitors all communications across all channels. The triage layer makes a 
 | R10 | Agent sessions accumulate memory without bounds | low | medium | 90-day retention policy (Section 9). OpenClaw memory has temporal decay. Monitor RSS via OTLP metric. |
 | R11 | Triage layer misclassifies important message as spam/noise | medium | high | Conservative initial thresholds (>0.95 confidence for destructive actions like archive). Triage log provides full audit trail. Dashboard surfaces triage activity for human review. Undo capability for autonomous actions where possible (unarchive, remove label). Start with rules-only triage, add model-based classification after confidence is established. |
 | R12 | Triage layer throughput bottleneck under high email volume | low | medium | Level 1 triage is rules-based (no model call), target <200ms. Batch processing for email inbox sync (historical messages). Monitor triage latency via OTLP. If bottleneck emerges, add message-level parallelism within triage layer. |
+| R14 | Beta version pin stability risk | medium | medium | v2026.3.2-beta.1 is a pre-release. Beta-caveat features (`message:preprocessed`, `sessionKey`, `onAgentEvent`, `onSessionTranscriptUpdate`, `requestHeartbeatNow()`, session attachments, `channelRuntime`, `transcribeAudioFile()`) may change API shape before stable release. Mitigation: (1) isolate beta-dependent code behind well-defined interfaces, (2) review trigger on stable release (D15), (3) rollback plan documented in D15 — revert to previous stable with custom alternatives for lost features. Stable features (Node.js >=22.12, `registerHttpRoute()`, ACP default, SecretRef expansion, bug fixes) carry no beta risk. |
 | R13 | Amara sends unauthorized message in monitored channel | low | critical | Triage layer structurally cannot send messages (D14). Orchestrator checks write permission before every outbound in monitored channels. Per-instruction grants expire after task completion. Standing rules require explicit config. Default is no-write. Audit log records grant type for every outbound message. |
 
 ## 12. Exit Criteria
@@ -657,21 +719,21 @@ Epic 1 (and all other epics) may not begin until **all** of the following are tr
 - [x] Happy-path data flow is documented end-to-end (Section 7) — plus error and escalation paths
 - [x] Non-functional requirements have numeric targets (Section 8) — all rows filled
 - [x] Security and privacy constraints are written (Section 9) — OAuth scopes, secrets, PII, audit, deletion
-- [x] Decision log has at least one entry per major decision (Section 10) — 15 entries documented (D0–D14)
+- [x] Decision log has at least one entry per major decision (Section 10) — 16 entries documented (D0–D15)
 - [x] No open questions remain that could block Epic 1 design
 
 ### Downstream Epic Verification
 
 | Epic | Key Question | Answered By |
 |---|---|---|
-| Epic 1 (Core Infrastructure) | What storage engine? What event delivery guarantee? What does the triage layer do? | D2 (SQLite), D3 (WAL queue), D13 (two-mode architecture) |
+| Epic 1 (Core Infrastructure) | What storage engine? What event delivery guarantee? What does the triage layer do? What Node.js version? | D2 (SQLite), D3 (WAL queue), D13 (two-mode architecture), D15 (Node.js >=22.12, version requirement) |
 | Epic 2 (Security & Privacy) | What OAuth scopes? Where do secrets live? | Section 9, D9 |
-| Epic 3 (Observability) | What telemetry system? | Section 2 (native OTLP), Section 8 (metrics) |
+| Epic 3 (Observability) | What telemetry system? What session correlation? | Section 2 (native OTLP), Section 8 (metrics), `sessionKey` in lifecycle hooks (D15, beta-caveat) |
 | Epic 4 (Agent Registry) | What format? Where does it live? | D10 (YAML+MD, file-based) |
-| Epic 5 (Orchestrator) | In-process or separate? How do agents communicate? What events reach the orchestrator? How are outbound messages authorized? | D1 (in-process), D7 (structured protocol), D13 (only direct + escalated events), D14 (write permission check before outbound in monitored channels) |
+| Epic 5 (Orchestrator) | In-process or separate? How do agents communicate? What events reach the orchestrator? How are outbound messages authorized? How is delegation tracked? | D1 (in-process), D7 (structured protocol), D13 (only direct + escalated events), D14 (write permission check before outbound in monitored channels), `onAgentEvent`/`onSessionTranscriptUpdate` for delegation tracking + session attachments for file passing (D15, beta-caveat) |
 | Epic 6 (Recovery & HITL) | How does escalation work? | Section 7 (escalation path) |
 | Epic 7 (Channel Platform) | Use platform adapters or custom? How are channels bound (account vs thread)? | D4, D5, D6, D11 (platform + normalization), D13 (channel binding model) |
 | Epic 8 (Channel Integrations) | WhatsApp/Gmail/Calendar strategy? What envelope format? What triage actions need Gmail API? How are outbound writes authorized? | D4, D5, D6, D11 (envelope + mode field), D13 (Gmail inbox management for triage), D14 (write permission model for monitored channels) |
 | Epic 9 (Specialist Agents) | How are agents defined and routed? | D10, Section 4 (registry) |
 | Epic 10 (Dashboard) | Where does it run? | D8 (Canvas/A2UI) |
-| Epic 11 (Onboarding) | What runtime? What config? | D0 (Node.js/OpenClaw), Section 6 (data stores) |
+| Epic 11 (Onboarding) | What runtime? What config? What version prerequisites? | D0 (Node.js/OpenClaw), Section 6 (data stores), D15 (OpenClaw v2026.3.2-beta.1 prerequisite, Node.js >=22.12) |

--- a/docs/epics/01-core-infrastructure.md
+++ b/docs/epics/01-core-infrastructure.md
@@ -36,7 +36,7 @@ Establishes the foundational persistence and event layer that every other epic b
 - [x] WAL mode: yes, enabled by default with `synchronous=FULL` for crash safety (D2, D3)
 - [x] Event bus implementation: SQLite WAL-mode queue with poll + mark-complete consumer — no in-process EventEmitter (D3)
 - [x] Task schema minimum fields: `task_id`, `state`, `channel`, `created_at`, `updated_at`, `correlation_id` (Epic 0, Section 6)
-- [x] Migration tool: Raw SQL files + hand-rolled runner. Numbered `.sql` files in `migrations/` (e.g., `001_initial_schema.sql`), `schema_version` table tracks applied migrations, runner reads in order, skips applied, wraps each in a transaction (~50 lines TS). Rationale: Node.js >=22 has built-in `node:sqlite`, schema is small (5-7 tables), avoids external deps, satisfies idempotency success metric.
+- [x] Migration tool: Raw SQL files + hand-rolled runner. Numbered `.sql` files in `migrations/` (e.g., `001_initial_schema.sql`), `schema_version` table tracks applied migrations, runner reads in order, skips applied, wraps each in a transaction (~50 lines TS). Rationale: Node.js >=22.12 has built-in `node:sqlite`, schema is small (5-7 tables), avoids external deps, satisfies idempotency success metric.
 
 ## Success Metrics
 
@@ -245,4 +245,4 @@ Phase 4 (unblocked by Phase 3):         │
 - ~~What fields does a Task record need at minimum?~~ **Resolved:** `task_id`, `state`, `channel`, `created_at`, `updated_at`, `correlation_id` (Epic 0, Section 6)
 - ~~Should the event bus be synchronous or async?~~ **Resolved:** Async — SQLite WAL queue with poll consumer (D3)
 - ~~Do we need soft-delete on tasks, or just a `failed`/`cancelled` state?~~ **Resolved:** No soft-delete; use `failed` state for terminal failures (Epic 0, Section 7)
-- ~~Migration tool: raw SQL files, a migration library, or hand-rolled?~~ **Resolved:** Raw SQL files + hand-rolled runner. Numbered `.sql` files in `migrations/`, `schema_version` table tracks applied migrations, ~50 lines TS. Node.js >=22 built-in `node:sqlite` eliminates external deps.
+- ~~Migration tool: raw SQL files, a migration library, or hand-rolled?~~ **Resolved:** Raw SQL files + hand-rolled runner. Numbered `.sql` files in `migrations/`, `schema_version` table tracks applied migrations, ~50 lines TS. Node.js >=22.12 built-in `node:sqlite` eliminates external deps.

--- a/docs/epics/02-security-and-privacy.md
+++ b/docs/epics/02-security-and-privacy.md
@@ -87,7 +87,7 @@ Establishes the security and privacy contracts for Amara before channels or depl
 
 ### S2.2: Implement secret storage
 
-**Description:** Verify and document the OpenClaw auth-profiles integration (D9) for storing OAuth tokens and other secrets. Confirm the file-based storage at `~/.openclaw/agents/{agentId}/agent/auth-profiles.json` works for Amara's needs.
+**Description:** Verify and document the OpenClaw auth-profiles integration (D9) for storing OAuth tokens and other secrets. Confirm the file-based storage at `~/.openclaw/agents/{agentId}/agent/auth-profiles.json` works for Amara's needs. Note: v2026.3.2-beta.1 expands SecretRef to support 64 targets with fail-fast validation — verify this covers Amara's secret indirection needs.
 
 **Acceptance Criteria:**
 - [ ] Auth-profiles path confirmed and documented
@@ -120,7 +120,7 @@ Establishes the security and privacy contracts for Amara before channels or depl
 
 ### S2.4: Define PII inventory and retention policy
 
-**Description:** Document all user data Amara stores, why it's stored, and how long it's retained. This is a policy document that gates data deletion implementation.
+**Description:** Document all user data Amara stores, why it's stored, and how long it's retained. This is a policy document that gates data deletion implementation. Note: `onSessionTranscriptUpdate` (v2026.3.2-beta.1, beta) data is PII-bearing — session transcript updates contain message content and must be included in the PII inventory and subject to the retention policy.
 
 **Acceptance Criteria:**
 - [ ] Inventory table: data field, storage location, purpose, retention period

--- a/docs/epics/03-observability-and-quality.md
+++ b/docs/epics/03-observability-and-quality.md
@@ -101,10 +101,11 @@ Wires in tracing, structured logging, agent outcome scoring, failure taxonomy, a
 
 ### S3.3: Implement correlation ID propagation
 
-**Description:** Ensure the `correlation_id` field from the tasks table is propagated through all OTLP spans and structured log entries for a request lifecycle. Any log or span produced while processing a task must include that task's correlation ID.
+**Description:** Ensure the `correlation_id` field from the tasks table is propagated through all OTLP spans and structured log entries for a request lifecycle. Any log or span produced while processing a task must include that task's correlation ID. The `sessionKey` from OpenClaw session lifecycle hooks (v2026.3.2-beta.1, beta — verify on stable) provides a native session identity that can be mapped to Amara's `correlation_id`, simplifying cross-system trace correlation.
 
 **Acceptance Criteria:**
 - [ ] `correlation_id` from task record injected into OTLP trace context
+- [ ] `sessionKey` (v2026.3.2-beta.1, beta) mapped to `correlation_id` for native session identity correlation
 - [ ] All structured log entries within a task's processing include `correlation_id`
 - [ ] Propagation works across event bus boundaries (producer → consumer)
 - [ ] Integration test: create task → process event → verify correlation_id in all spans/logs
@@ -168,7 +169,7 @@ Wires in tracing, structured logging, agent outcome scoring, failure taxonomy, a
 
 ### S3.7: Define metrics and their collection points
 
-**Description:** Document all OTLP metrics Amara will emit, where they are emitted from (collection points), and who consumes them. This is a reference document that guides instrumentation across all epics.
+**Description:** Document all OTLP metrics Amara will emit, where they are emitted from (collection points), and who consumes them. This is a reference document that guides instrumentation across all epics. New hook events from v2026.3.2-beta.1 (`onAgentEvent`, `onSessionTranscriptUpdate`, `message:preprocessed`) provide additional native collection points for delegation metrics, transcript tracking, and message preprocessing latency.
 
 **Acceptance Criteria:**
 - [ ] Metrics inventory table: metric name, type (counter/histogram/gauge), unit, collection point, consumer
@@ -219,6 +220,7 @@ Phase 3 (unblocked by Phase 2):
 
 - Epic 0 (architecture gate)
 - Epic 1 (core infrastructure) — event bus used to emit observability events
+- Note: `sessionKey` (v2026.3.2-beta.1, beta) simplifies S3.3 correlation ID propagation by providing native session identity
 
 ## Open Questions
 

--- a/docs/epics/04-agent-registry-and-routing.md
+++ b/docs/epics/04-agent-registry-and-routing.md
@@ -29,6 +29,8 @@ Defines the agent definition format, implements the registry that loads and vali
 ## Key Decisions
 
 - [x] Bundle format: YAML front-matter + markdown body, file-based — loaded from disk at startup (D10)
+- [x] ACP dispatch: default-enabled in v2026.3.2-beta.1 (stable change). All agent bundles must account for ACP as the default delegation transport.
+- [x] `tools.profile` requirement: v2026.3.2-beta.1 changed the default `tools.profile` behavior (stable, breaking change). Agent bundle schema MUST include `tools.profile` as a **required field** to prevent breakage from the default change. See [Section 1.6 migration checklist](00-integration-architecture.md#16-minimum-openclaw-version).
 - [ ] How are agent capabilities declared? (tags, skill list, free-text, embedding?)
 - [ ] Routing algorithm: keyword match / embedding similarity / model-based classifier?
 - [ ] How are agents versioned? (semver in YAML / git tag?)
@@ -55,6 +57,7 @@ Defines the agent definition format, implements the registry that loads and vali
 
 | Risk | Mitigation |
 |------|-----------|
+| `tools.profile` default change breaks agent tool access | All bundles MUST declare `tools.profile` explicitly. Schema validation rejects bundles without it. See [migration checklist](00-integration-architecture.md#16-minimum-openclaw-version). |
 | Routing logic too naive for real tasks | Start with keyword/tag matching; plan upgrade path to embedding |
 | Agent bundle format too rigid to extend | Keep format open; use semver to evolve |
 | Generic doer becomes a dumping ground | Define explicit "I don't know" escalation path |
@@ -63,8 +66,8 @@ Defines the agent definition format, implements the registry that loads and vali
 
 > Placeholder — to become GitHub issues.
 
-- [ ] Define agent bundle schema (YAML front-matter + markdown body — D10)
-- [ ] Implement registry loader and validator
+- [ ] Define agent bundle schema (YAML front-matter + markdown body — D10). Schema MUST include mandatory `tools.profile` field (v2026.3.2-beta.1 breaking change — prevents silent default behavior)
+- [ ] Implement registry loader and validator (reject bundles missing `tools.profile`)
 - [ ] Implement schema validation for agent bundles (D10 consequence — reject malformed bundles)
 - [ ] Define three agent types
 - [ ] Implement routing / matching algorithm

--- a/docs/epics/05-orchestrator.md
+++ b/docs/epics/05-orchestrator.md
@@ -17,7 +17,9 @@ The always-on brain. Receives events from the event queue (direct messages + tri
 - Inbound event handler (receives from event queue — direct messages + triage escalations, D13)
 - Immediate acknowledgment logic (<1s template response before planning — Epic 0, Section 8)
 - Task planner (break request into subtasks)
-- Agent delegation via OpenClaw `agentToAgent` + Amara structured protocol (D7)
+- Agent delegation via OpenClaw `agentToAgent` + Amara structured protocol (D7) — ACP dispatch default-enabled (v2026.3.2-beta.1, stable)
+- Delegation tracking via `onAgentEvent` and `onSessionTranscriptUpdate` (v2026.3.2-beta.1, beta — verify on stable). Note: `onSessionTranscriptUpdate` data is PII-bearing and subject to Epic 2 retention policy.
+- Session attachments for file passing between orchestrator and specialist agents (v2026.3.2-beta.1, beta — verify on stable)
 - Status tracking (in-progress, blocked, complete)
 - Task summarization on completion
 - D14 write permission check on outbound messages (monitored channels require explicit grant)
@@ -33,8 +35,9 @@ The always-on brain. Receives events from the event queue (direct messages + tri
 ## Key Decisions
 
 - [x] Orchestrator location: in-process OpenClaw tool plugin (D1)
-- [x] Delegation interface: OpenClaw `agentToAgent` + Amara structured protocol (D7)
+- [x] Delegation interface: OpenClaw `agentToAgent` + Amara structured protocol (D7) — ACP dispatch default-enabled (v2026.3.2-beta.1, stable)
 - [x] Acknowledgment: <1s template response before planning begins (Epic 0, Section 8)
+- [x] Delegation progress tracking: via native `onAgentEvent`/`onSessionTranscriptUpdate` runtime events (D15, beta — verify on stable). Provides real-time delegation status without polling.
 - [ ] What model does the orchestrator use? ("fast model" — specific model TBD)
 - [ ] Are subtasks run sequentially or in parallel by default?
 
@@ -61,7 +64,7 @@ The always-on brain. Receives events from the event queue (direct messages + tri
 | Risk | Mitigation |
 |------|-----------|
 | Orchestrator model produces inconsistent plans | Add structured output validation; log all plans for inspection |
-| Agent delegation hangs indefinitely | Timeout + stall detection (Epic 6) |
+| Agent delegation hangs indefinitely | Timeout + stall detection (Epic 6). `onAgentEvent` (v2026.3.2-beta.1, beta) enables early stall detection via runtime event monitoring. Note: `onSessionTranscriptUpdate` data is PII-bearing — subject to Epic 2 retention policy. |
 | Acknowledgment delayed by planning | Acknowledge before planning — two separate steps |
 | Parallel subtasks create conflicting writes | Decide concurrency model in Epic 0 |
 
@@ -72,7 +75,9 @@ The always-on brain. Receives events from the event queue (direct messages + tri
 - [ ] Implement inbound event handler (consumes from event queue — direct + escalated events)
 - [ ] Implement immediate acknowledgment (<1s template response — Section 8)
 - [ ] Implement task planner
-- [ ] Implement agent delegation interface (OpenClaw `agentToAgent` — D7)
+- [ ] Implement agent delegation interface (OpenClaw `agentToAgent` — D7, ACP default-enabled)
+- [ ] Implement delegation progress tracking via `onAgentEvent`/`onSessionTranscriptUpdate` (D15, beta-caveat)
+- [ ] Implement session attachment file passing for delegation (D15, beta-caveat)
 - [ ] Wire task status transitions
 - [ ] Implement task summarization
 - [ ] Implement D14 write permission authorization (check grant before outbound on monitored channels)
@@ -90,4 +95,4 @@ The always-on brain. Receives events from the event queue (direct messages + tri
 
 - What fast model does Amara run on in v1?
 - ~~Does the orchestrator maintain conversation context across turns, or is each request independent?~~ **Partially resolved:** Orchestrator receives only direct + escalated events from the queue (D13); memory is handled by OpenClaw native memory + Amara Task DB for task context (D12)
-- How are parallel subtasks coordinated — and what happens if one fails?
+- How are parallel subtasks coordinated — and what happens if one fails? *(Note: `onAgentEvent` from v2026.3.2-beta.1 makes parallel subtask monitoring more viable — each subtask's runtime events can be tracked independently)*

--- a/docs/epics/06-recovery-and-human-in-the-loop.md
+++ b/docs/epics/06-recovery-and-human-in-the-loop.md
@@ -15,6 +15,7 @@ Handles what happens when tasks stall, agents fail, or Amara genuinely needs a h
 
 **In:**
 - Follow-up scheduler (re-check in-progress tasks on a configurable interval)
+- `requestHeartbeatNow()` for on-demand re-checks (v2026.3.2-beta.1, beta — verify on stable). Enables immediate scheduler trigger without waiting for next heartbeat interval.
 - Stall detection (task has been in-progress too long without progress)
 - Human escalation (send a question to the human via the originating channel)
 - Retry-with-feedback (re-run agent with human answer appended to context)
@@ -65,7 +66,7 @@ Handles what happens when tasks stall, agents fail, or Amara genuinely needs a h
 
 > Placeholder — to become GitHub issues.
 
-- [ ] Implement follow-up scheduler
+- [ ] Implement follow-up scheduler (with `requestHeartbeatNow()` for on-demand re-checks — D15, beta-caveat)
 - [ ] Implement stall detection
 - [ ] Implement human escalation with question formatting
 - [ ] Implement retry-with-feedback
@@ -80,6 +81,6 @@ Handles what happens when tasks stall, agents fail, or Amara genuinely needs a h
 
 ## Open Questions
 
-- Should the scheduler be a cron job, a setInterval, or event-driven (e.g., on task update)? *(Note: architecture.md describes the scheduler as heartbeat-driven)*
+- Should the scheduler be a cron job, a setInterval, or event-driven (e.g., on task update)? *(Note: architecture.md describes the scheduler as heartbeat-driven. `requestHeartbeatNow()` from v2026.3.2-beta.1 provides an on-demand trigger — the scheduler can use both periodic heartbeats AND event-driven triggers for immediate re-checks.)*
 - How does the human reply get correlated back to the task? (reply detection / explicit command?)
 - Is there a maximum number of retries before a task is permanently failed?

--- a/docs/epics/07-channel-platform.md
+++ b/docs/epics/07-channel-platform.md
@@ -23,6 +23,8 @@ Defines the stable adapter contract that all channel integrations (Epic 8) must 
 - Channel binding configuration: which channels are `direct` vs `monitored` (D13)
 - `thread_ref` field for conversation threading context (open — not yet specified)
 - Write permission enforcement: outbound on monitored channels blocked unless grant exists (D14)
+- `message:preprocessed` hook as candidate triage interception point (v2026.3.2-beta.1, beta — verify event shape provides sufficient context for mode routing before adoption)
+- `channelRuntime` on gateway context for channel state inspection (v2026.3.2-beta.1, beta — verify on stable)
 
 **Out:**
 - Specific channel implementations (Epic 8)
@@ -31,6 +33,8 @@ Defines the stable adapter contract that all channel integrations (Epic 8) must 
 ## Key Decisions
 
 - [x] Adapter interface: TypeScript — OpenClaw is Node.js/TypeScript (D0)
+- [x] Triage interception hook: `message:preprocessed` (v2026.3.2-beta.1, beta — verify event shape on stable). Provides early message access before standard processing. Evaluate whether event shape includes sufficient context for mode routing during implementation.
+- [x] Channel state inspection: `channelRuntime` on gateway context (v2026.3.2-beta.1, beta — verify on stable). Enables runtime health checks and adapter state access.
 - [ ] How is inbound idempotency implemented? (message ID deduplication table?) *(P0 gap: cross-channel task-level dedup — Epic 0, Section 3)*
 - [ ] Retry strategy: exponential backoff / fixed interval / channel-specific?
 - [ ] How are channel-level errors surfaced to the orchestrator?
@@ -68,6 +72,8 @@ Defines the stable adapter contract that all channel integrations (Epic 8) must 
 
 - [ ] Define adapter interface (TypeScript — D0)
 - [ ] Define AmaraEvent envelope schema with `mode` field (D11, D13)
+- [ ] Evaluate `message:preprocessed` hook for triage interception (D15, beta-caveat)
+- [ ] Implement `channelRuntime` integration for adapter health and state inspection (D15, beta-caveat)
 - [ ] Implement channel binding configuration (direct vs monitored per channel — D13)
 - [ ] Implement thread context resolution (`thread_ref` for conversation threading)
 - [ ] Define auth/webhook lifecycle

--- a/docs/epics/08-channel-integrations.md
+++ b/docs/epics/08-channel-integrations.md
@@ -21,6 +21,8 @@ Implements WhatsApp, Gmail, and Calendar on top of the Channel Platform (Epic 7)
 - Channel binding configuration: which channels/threads are "direct" (to Amara) vs "monitored" (passive observation)
 - Channel write permission enforcement: monitored channels allow read + silent triage actions (archive, label, mark read, draft) but no outbound messaging by default; sending requires explicit authorization (per-instruction or standing rule per D14)
 - Channel-specific auth flows: QR/pairing session for WhatsApp (Baileys), OAuth2 for Gmail/Calendar (via `gog auth`)
+- `channelRuntime` on gateway context for adapter health checks (v2026.3.2-beta.1, beta — verify on stable)
+- **P2 enhancement (not v1 scope):** Voice message transcription via `transcribeAudioFile()` (v2026.3.2-beta.1, beta). WhatsApp voice messages are out of scope for current milestones (1-5). Available for future implementation when voice channel support is prioritized.
 
 **Out:**
 - Adapter interface definition (Epic 7)
@@ -61,6 +63,7 @@ Implements WhatsApp, Gmail, and Calendar on top of the Channel Platform (Epic 7)
 | WhatsApp API changes break adapter | Pin API version; monitor changelogs |
 | Calendar API quota limits | Cache reads; batch writes |
 | OAuth token refresh fails silently | Explicit refresh error handling; alert to human |
+| Discord channel changes | No impact — Discord is not in Milestone 1-5 scope. No changes needed for v2026.3.2-beta.1 compatibility. |
 
 ## Stories
 
@@ -75,6 +78,7 @@ Implements WhatsApp, Gmail, and Calendar on top of the Channel Platform (Epic 7)
 - [ ] Write end-to-end test per channel
 - [ ] Document auth flow per channel (QR/pairing for WhatsApp, OAuth2 for Gmail/Calendar)
 - [ ] Document message normalization (AmaraEvent envelope with `mode` field)
+- [ ] **(P2 — deferred)** Implement voice message transcription via `transcribeAudioFile()` (v2026.3.2-beta.1, beta). Not in v1 scope — WhatsApp voice messages require additional handling (media download, format conversion) beyond the transcription API itself.
 
 ## Dependencies
 

--- a/docs/epics/09-specialist-agents.md
+++ b/docs/epics/09-specialist-agents.md
@@ -21,6 +21,7 @@ Implements the specialist agents that Amara delegates to: Comms, Research, Codin
 - Generic Doer (broad capability fallback)
 - Agent bundle files for each (YAML front-matter + markdown body — D10)
 - Structured input/output contracts per agent (using Amara structured protocol — D7)
+- Session attachments for file passing between orchestrator and agents (v2026.3.2-beta.1, beta — verify on stable)
 
 **Out:**
 - Agent routing (Epic 4)
@@ -32,6 +33,8 @@ Implements the specialist agents that Amara delegates to: Comms, Research, Codin
 - [ ] What model does each agent use? (cost vs. capability tradeoff)
 - [ ] What tools does each agent have access to? (web search / code interpreter / file system?)
 - [ ] Structured output format: JSON schema / TypeScript type / Zod?
+- [x] File passing between agents: via session attachments (v2026.3.2-beta.1, beta — verify on stable). Enables structured file handoff without filesystem workarounds.
+- [x] `tools.profile` requirement: all agent bundles must explicitly declare `tools.profile` (v2026.3.2-beta.1 breaking change). See [Epic 4 schema](04-agent-registry-and-routing.md) and [migration checklist](00-integration-architecture.md#16-minimum-openclaw-version).
 - [x] How long can an agent run? <45s P95, with interim updates every 15s (Epic 0, Section 8)
 - [ ] How do agents handle "I can't do this"?
 
@@ -57,6 +60,7 @@ Implements the specialist agents that Amara delegates to: Comms, Research, Codin
 
 | Risk | Mitigation |
 |------|-----------|
+| `tools.profile` default change breaks agent tool access | All agent bundles MUST declare `tools.profile` explicitly. See [Epic 4 migration checklist](00-integration-architecture.md#16-minimum-openclaw-version). |
 | Agent scope creep (agents doing work outside their mandate) | Strict tool access lists; mandate review in bundle |
 | Agents produce inconsistent output formats | Structured output validation on every response |
 | Generic Doer too capable — routing always falls through to it | Monitor routing distribution; tune routing logic |
@@ -66,6 +70,8 @@ Implements the specialist agents that Amara delegates to: Comms, Research, Codin
 
 > Placeholder — to become GitHub issues.
 
+- [ ] Configure `tools.profile` for all agent bundles (required field — v2026.3.2-beta.1 breaking change)
+- [ ] Implement session attachment file passing for agent delegation (D15, beta-caveat)
 - [ ] Define structured input/output contracts
 - [ ] Implement Comms agent
 - [ ] Implement Research agent

--- a/docs/epics/10-dashboard.md
+++ b/docs/epics/10-dashboard.md
@@ -191,7 +191,7 @@ A minimal web UI for task visibility: active tasks, pending tasks, history, and 
 **Description:** Integrate the dashboard into Amara's runtime as a same-process Gateway HTTP endpoint (D8). Implement WebSocket push for real-time updates instead of polling.
 
 **Acceptance Criteria:**
-- [ ] Dashboard static assets served from Gateway HTTP endpoint
+- [ ] Dashboard static assets served from Gateway HTTP endpoint (must use `registerHttpRoute()` — not removed `registerHttpHandler()` — for route registration per v2026.3.2-beta.1 breaking change)
 - [ ] WebSocket endpoint established for push updates
 - [ ] Task state changes pushed to connected dashboard clients
 - [ ] Triage log entries pushed to connected dashboard clients

--- a/docs/epics/11-onboarding-and-deployment.md
+++ b/docs/epics/11-onboarding-and-deployment.md
@@ -14,7 +14,7 @@ The install flow, account connection, and getting-started documentation. The goa
 ## Scope
 
 **In:**
-- Prerequisites documentation (Node.js 22+, OpenClaw Gateway, Google OAuth credentials, accounts needed)
+- Prerequisites documentation (Node.js >=22.12, OpenClaw Gateway v2026.3.2-beta.1 or later (D15), Google OAuth credentials, accounts needed)
 - Install steps (clone, install deps, configure)
 - Account connection flow for each channel
 - Environment variable / config file documentation
@@ -63,8 +63,10 @@ The install flow, account connection, and getting-started documentation. The goa
 
 > Placeholder — to become GitHub issues.
 
-- [ ] Document prerequisites
+- [ ] Document prerequisites (Node.js >=22.12, OpenClaw v2026.3.2-beta.1 — D15)
 - [ ] Document install steps
+- [ ] Add `openclaw config validate --json` verification step to install flow (v2026.3.2-beta.1)
+- [ ] Document `tools.profile` configuration requirements for agent bundles (v2026.3.2-beta.1 breaking change)
 - [ ] Document WhatsApp account connection
 - [ ] Document Gmail account connection
 - [ ] Document Calendar account connection

--- a/docs/milestone-1-plan.md
+++ b/docs/milestone-1-plan.md
@@ -27,7 +27,7 @@ Milestone 1 covers Epics 1, 2, 3, and 10: the foundational infrastructure, secur
 | S2.8 | Document input validation contracts | S | 2 | — | — |
 | S3.1 | Define structured logging standard | S | 3 | — | S2.3, S3.3 |
 | S3.2 | Implement OTLP/OpenTelemetry integration | M | 3 | — | S3.3, S3.7, S3.8 |
-| S3.3 | Implement correlation ID propagation | M | 3 | S1.1, S3.2 | — |
+| S3.3 | Implement correlation ID propagation (+ `sessionKey` mapping — D15 beta) | M | 3 | S1.1, S3.2 | — |
 | S3.4 | Define and implement agent outcome scoring | M | 3 | S1.1, S1.9 | S3.6 |
 | S3.5 | Document failure taxonomy | S | 3 | — | S3.6 |
 | S3.6 | Build eval harness | L | 3 | S3.4, S3.5 | — |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,8 @@ Milestones follow epic dependencies. No milestone begins until its predecessors 
 - [x] NFRs, security constraints, and decision log documented
 - [x] Exit criteria met → implementation unlocked
 
+**OpenClaw version requirement:** v2026.3.2-beta.1 or later ([D15](epics/00-integration-architecture.md#10-decision-log))
+
 ## Milestone 1 — Foundation + Visibility
 
 **Epics:** 1, 2, 3, 10
@@ -93,7 +95,7 @@ Items not assigned to a milestone yet:
 
 - Triage model tuning (graduate from rules engine to ML classifier — D13)
 - User-authored recurring tasks (beyond core follow-up scheduler, which is P0 in Epic 1)
-- Sub-agent progress relay (real-time status)
+- Sub-agent progress relay (real-time status) — implementation approach available via `onAgentEvent`/`onSessionTranscriptUpdate` (v2026.3.2-beta.1, beta — verify on stable); core logic in Epic 5
 - Model-based routing (replace keyword heuristics)
 - Multi-user support
 - Additional channels (Slack, SMS, etc.)


### PR DESCRIPTION
## Summary

- Update 15 documentation files to reflect OpenClaw v2026.3.2-beta.1 capabilities before implementation begins
- Add Section 1.6 (Minimum OpenClaw Version) to Epic 0 as the gate document for all version-dependent features
- Add D15 decision (version pin) with review trigger, rollback plan, and migration checklists
- Update capabilities matrix, gap analysis, and all downstream epic specs with new hooks and features
- Categorize changes as stable (unconditional) vs beta-caveat (verify on stable release)

## Test plan

- [x] `grep -r "27 hook" docs/` returns 0 results (all updated to 31)
- [x] `grep -rP "Node\.js (22\+|>=22[^.])" docs/` returns 0 results (all updated to >=22.12)
- [x] `grep -r "v2026.3.2-beta.1" docs/` returns hits in 13 files (Epic 0, architecture.md, roadmap.md, and 10 epic specs)
- [x] `registerHttpHandler` only appears in migration/breaking-change context
- [x] D15 exists with review trigger and rollback plan
- [x] R14 documents beta stability risk
- [x] Exit criteria says "16 entries (D0-D15)"
- [x] All beta-caveat features marked with "(beta — verify on stable)"
- [x] `tools.profile` documented as required field in Epic 4
- [x] `onSessionTranscriptUpdate` PII note in Epic 2 and Epic 5
- [x] Cross-references between files are consistent

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)